### PR TITLE
Add a service to retrieve identity of current user

### DIFF
--- a/src/Smart.FA.Catalog.Core/Domain/Models/CustomIdentity.cs
+++ b/src/Smart.FA.Catalog.Core/Domain/Models/CustomIdentity.cs
@@ -1,22 +1,24 @@
 using System.Security.Principal;
-using Core.Domain;
 
-namespace Web.Identity;
+namespace Core.Domain.Models;
 
 public class CustomIdentity : IIdentity
 {
-    public Trainer Trainer { get; }
+    public int Id { get; set; }
 
+    public Trainer Trainer { get; }
 
     public string AuthenticationType => "Custom";
 
     public bool IsAuthenticated => true;
+
     public string? Name { get; }
 
     public CustomIdentity(Trainer trainer)
     {
         Trainer = trainer;
-        Name = GetUserData();
+        Id      = trainer.Id;
+        Name    = GetUserData();
     }
 
     public override string ToString()
@@ -24,6 +26,5 @@ public class CustomIdentity : IIdentity
         return GetUserData();
     }
 
-    public string GetUserData()
-        => $"{Trainer.Name.FirstName} {Trainer.Name.LastName}";
+    public string GetUserData() => $"{Trainer.Name.FirstName} {Trainer.Name.LastName}";
 }

--- a/src/Smart.FA.Catalog.Core/Domain/Models/CustomIdentity.cs
+++ b/src/Smart.FA.Catalog.Core/Domain/Models/CustomIdentity.cs
@@ -4,7 +4,7 @@ namespace Core.Domain.Models;
 
 public class CustomIdentity : IIdentity
 {
-    public int Id { get; set; }
+    public int Id => Trainer.Id;
 
     public Trainer Trainer { get; }
 
@@ -17,14 +17,13 @@ public class CustomIdentity : IIdentity
     public CustomIdentity(Trainer trainer)
     {
         Trainer = trainer;
-        Id      = trainer.Id;
-        Name    = GetUserData();
+        Name    = GetUserFormattedName();
     }
 
     public override string ToString()
     {
-        return GetUserData();
+        return GetUserFormattedName();
     }
 
-    public string GetUserData() => $"{Trainer.Name.FirstName} {Trainer.Name.LastName}";
+    public string GetUserFormattedName() => $"{Trainer.Name.FirstName} {Trainer.Name.LastName}";
 }

--- a/src/Smart.FA.Catalog.Core/Services/IUserIdentity.cs
+++ b/src/Smart.FA.Catalog.Core/Services/IUserIdentity.cs
@@ -1,0 +1,25 @@
+using Core.Domain;
+using Core.Domain.Models;
+
+namespace Core.Services;
+
+/// <summary>
+/// Exposes the <see cref="CustomIdentity" /> of the current connected user.
+/// </summary>
+public interface IUserIdentity
+{
+    /// <summary>
+    /// Id of the current user.
+    /// </summary>
+    public int Id { get; }
+
+    /// <summary>
+    /// The identity of the connected user.
+    /// </summary>
+    public CustomIdentity Identity { get; init; }
+
+    /// <summary>
+    /// <see cref="Trainer" /> instance of the current connected user.
+    /// </summary>
+    public Trainer CurrentTrainer { get; init; }
+}

--- a/src/Smart.FA.Catalog.Web/Extensions/Middlewares/ProxyHeaderMiddleware.cs
+++ b/src/Smart.FA.Catalog.Web/Extensions/Middlewares/ProxyHeaderMiddleware.cs
@@ -2,9 +2,9 @@ using System.Globalization;
 using System.Security.Principal;
 using Application.UseCases.Queries;
 using Core.Domain.Enumerations;
+using Core.Domain.Models;
 using Core.SeedWork;
 using MediatR;
-using Web.Identity;
 
 namespace Web.Extensions.Middlewares;
 

--- a/src/Smart.FA.Catalog.Web/Identity/UserIdentity.cs
+++ b/src/Smart.FA.Catalog.Web/Identity/UserIdentity.cs
@@ -1,0 +1,27 @@
+using Core.Domain;
+using Core.Domain.Models;
+using Core.Services;
+
+namespace Web.Identity;
+
+/// <inheritdoc />
+public class UserIdentity : IUserIdentity
+{
+    /// <inheritdoc />
+    public int Id => Identity.Id;
+
+    /// <inheritdoc />
+    public CustomIdentity Identity { get; init; }
+
+    /// <inheritdoc />
+    public Trainer CurrentTrainer { get; init; }
+
+    public UserIdentity(IHttpContextAccessor httpContextAccessor)
+    {
+        var identity = httpContextAccessor.HttpContext?.User.Identity as CustomIdentity ??
+                       throw new InvalidOperationException("Cannot retrieve identity of current user.");
+
+        Identity       = identity;
+        CurrentTrainer = identity.Trainer;
+    }
+}

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
@@ -1,6 +1,6 @@
+using Core.Domain.Models;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Web.Identity;
 
 namespace Web.Pages.Admin.Trainings.Create;
 

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml.cs
@@ -1,12 +1,12 @@
 using Application.UseCases.Commands;
 using Application.UseCases.Queries;
 using Core.Domain.Dto;
+using Core.Domain.Models;
 using Core.SeedWork;
 using Infrastructure.Persistence;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Web.Identity;
 using Web.Options;
 
 namespace Web.Pages.Admin.Trainings.List;

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
@@ -1,7 +1,7 @@
 using Application.UseCases.Queries;
+using Core.Domain.Models;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Web.Identity;
 
 namespace Web.Pages.Admin.Trainings.Update;
 

--- a/src/Smart.FA.Catalog.Web/Pages/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Index.cshtml.cs
@@ -1,6 +1,6 @@
+using Core.Domain.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Web.Identity;
 using Web.Pages.Admin;
 
 namespace Web.Pages;


### PR DESCRIPTION
This commit introduce a service that can be used across all layers.
Currently the Identity is strongly typed inside the HttpContext. 
Therefore only the Web layer can retrieve current user identity.
By adding a service that provides the identity through DI we can retrieve the identity at the infrastructure or application layer.