### PR TITLE
AppSettings: revert default environment from Local to Development

### DIFF
--- a/src/Smart.FA.Catalog.Web/Program.cs
+++ b/src/Smart.FA.Catalog.Web/Program.cs
@@ -7,7 +7,10 @@ using FluentValidation.AspNetCore;
 using NLog.Web;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddJsonFile("appsettings.Local.json", true, true);
+
+// appsettings.Local.json will have precedence over anything else as it is set in last.
+// https://github.com/dotnet/aspnetcore/blob/c5207d21ed68041879e1256406b458d130b420ab/src/DefaultBuilder/src/WebHost.cs#L170
+builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
 
 builder.Host.UseNLog();
 

--- a/src/Smart.FA.Catalog.Web/Program.cs
+++ b/src/Smart.FA.Catalog.Web/Program.cs
@@ -7,8 +7,7 @@ using FluentValidation.AspNetCore;
 using NLog.Web;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.SetBasePath(Directory.GetCurrentDirectory())
-    .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json");
+builder.Configuration.AddJsonFile("appsettings.Local.json", true, true);
 
 builder.Host.UseNLog();
 

--- a/src/Smart.FA.Catalog.Web/Properties/launchSettings.json
+++ b/src/Smart.FA.Catalog.Web/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:7091;http://localhost:5091",
       "dotnetRunMessages": true

--- a/src/Smart.FA.Catalog.Web/appsettings.Development.json
+++ b/src/Smart.FA.Catalog.Web/appsettings.Development.json
@@ -9,8 +9,8 @@
   "AllowedHosts": "*",
   "DetailedErrors": true,
   "ConnectionStrings": {
-    "Catalog": "Server=172.22.1.3,1433; Database=Catalog; User Id =SA; Password=localStoragePassword!",
-    "Account": "Server=host.docker.internal,1433; Database=Account; User Id =SA; Password=localStoragePassword!"
+    "Catalog": "Server=(LocalDB)\\MSSQLLocalDB; Database=Catalog; Integrated Security=true;",
+    "Account": "Server=(LocalDB)\\MSSQLLocalDB; Database=Catalog; Integrated Security=true;"
   },
   "MailOptions": {
     "Server": "",


### PR DESCRIPTION
The application fails to build from a fresh clone. This is due to the fact the appsettings.Local.json is mandatory and not integrated in the repository.
Conceptually the appsettings.Local.json should be optional and give the possiblity to override appsettings.Development.json's default settings.
Default connection string for Catalog has been set to "(LocalDB)\\MSSQLLocalDB; Database=Catalog; Integrated Security=true;".