### PR TITLE
Refactor the javascript that scroll and focus to the first HTML element in an error state

### DIFF
--- a/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -80,24 +80,8 @@
 <script src="~/js/lib.js"></script>
 
 <script>
-        window.addEventListener('load',
-            function() {
-                var elem = document.getElementById('@ViewData["SelectedSideMenuItem"]');
-                //elem.classList.add("c-side-menu__item--active");
-
-                var elementsInError = document.getElementsByClassName('c-input--error');
-                if (elementsInError.length) {
-                    var firstInvalidControl = elementsInError[0];
-                    var labelOffset = 500;
-                    window.scroll({
-                        top: (firstInvalidControl.getBoundingClientRect().top + window.scrollY - labelOffset),
-                        left: 0,
-                        behavior: "smooth"
-                    });
-                    firstInvalidControl.focus();
-                };
-            });
-    </script>
+    RegisterScrollToFirstElementInError();
+</script>
 
 @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
+++ b/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
@@ -8,3 +8,22 @@ $(document).ready(
             model.value = true;
         });
     });
+
+// Scrolls to the first HTML element that has a class attribute ending with '--error'
+function scrollToFirstErrorElement() {
+    let elementsInError = document.querySelectorAll("*[class*='--error']");
+    if (elementsInError.length) {
+        let firstInvalidControl = elementsInError[0];
+        let labelOffset = 500;
+        window.scroll({
+            top: (firstInvalidControl.getBoundingClientRect().top + window.scrollY - labelOffset),
+            left: 0,
+            behavior: "smooth"
+        });
+        firstInvalidControl.focus();
+    };
+}
+
+function RegisterScrollToFirstElementInError() {
+    window.addEventListener("load", scrollToFirstErrorElement);
+}


### PR DESCRIPTION
When the validation fails, we want to have the first element to be scrolled to and focused.
The reason is that if the failures is deep at the bottom of a page it is not user friendly to understand there was an error.