### PR TITLE
Divide proxy header middleware in multiple commands/queries

### DIFF
--- a/src/Smart.FA.Catalog.Application/UseCases/Commands/CreateTrainerFromUserAppCommandHandler.cs
+++ b/src/Smart.FA.Catalog.Application/UseCases/Commands/CreateTrainerFromUserAppCommandHandler.cs
@@ -1,0 +1,74 @@
+﻿using Application.SeedWork;
+using Core.Domain;
+using Core.Domain.Dto;
+using Core.Domain.Enumerations;
+using Core.LogEvents;
+using Core.SeedWork;
+using Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.UseCases.Commands;
+
+public class
+    CreateTrainerFromUserAppCommandHandler : IRequestHandler<CreateTrainerFromUserAppRequest,
+        CreateTrainerFromUserAppResponse>
+{
+    private readonly ILogger<CreateTrainerFromUserAppCommandHandler> _logger;
+    private readonly CatalogContext _context;
+
+    public CreateTrainerFromUserAppCommandHandler
+    (
+        ILogger<CreateTrainerFromUserAppCommandHandler> logger
+        , CatalogContext context
+    )
+    {
+        _logger = logger;
+        _context = context;
+    }
+
+    public async Task<CreateTrainerFromUserAppResponse> Handle(CreateTrainerFromUserAppRequest command,
+        CancellationToken cancellationToken)
+    {
+        CreateTrainerFromUserAppResponse appResponse = new();
+
+        var linkedTrainer = new Trainer
+        (
+            Name.Create
+            (
+                command.User.FirstName
+                , command.User.LastName
+            ).Value
+            , TrainerIdentity.Create
+            (
+                command.User.UserId
+                , Enumeration.FromDisplayName<ApplicationType>(command.User.ApplicationType)
+            ).Value
+            , string.Empty
+            , string.Empty
+            , Language.Create("EN").Value
+        );
+        _context.Trainers.Add(linkedTrainer);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(LogEventIds.TrainerCreated,
+            "A new trainer for user id {UserId}, application type {ApplicationType} was created", command.User.UserId,
+            command.User.ApplicationType);
+
+        appResponse.Trainer = linkedTrainer;
+
+        appResponse.SetSuccess();
+
+        return appResponse;
+    }
+}
+
+public class CreateTrainerFromUserAppRequest : IRequest<CreateTrainerFromUserAppResponse>
+{
+    public UserDto User { get; set; } = null!;
+}
+
+public class CreateTrainerFromUserAppResponse : ResponseBase
+{
+    public Trainer Trainer { get; set; } = null!;
+}

--- a/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainerFromUserAppQueryHandler.cs
+++ b/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainerFromUserAppQueryHandler.cs
@@ -1,8 +1,8 @@
 using Application.SeedWork;
 using Core.Domain;
+using Core.Domain.Dto;
 using Core.Domain.Enumerations;
-using Core.SeedWork;
-using Core.Services;
+using Core.Exceptions;
 using Infrastructure.Persistence;
 using Infrastructure.Services;
 using MediatR;
@@ -11,57 +11,51 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.UseCases.Queries;
 
-public class GetTrainerFromUserAppQueryHandler : IRequestHandler<GetTrainerFromUserAppRequest, GetTrainerFromUserAppResponse>
+public class
+    GetTrainerFromUserAppQueryHandler : IRequestHandler<GetTrainerFromUserAppRequest, GetTrainerFromUserAppResponse>
 {
     private readonly ILogger<GetTrainerFromUserAppQueryHandler> _logger;
+    private readonly CatalogContext _context;
     private readonly UserStrategyResolver _userStrategyResolver;
-    private readonly CatalogContext _catalogContext;
 
-    public GetTrainerFromUserAppQueryHandler(ILogger<GetTrainerFromUserAppQueryHandler> logger,
-        UserStrategyResolver userStrategyResolver, CatalogContext catalogContext)
+    public GetTrainerFromUserAppQueryHandler
+    (
+        ILogger<GetTrainerFromUserAppQueryHandler> logger
+        , CatalogContext context
+        , UserStrategyResolver userStrategyResolver
+    )
     {
         _logger = logger;
+        _context = context;
         _userStrategyResolver = userStrategyResolver;
-        _catalogContext = catalogContext;
     }
 
-    public async Task<GetTrainerFromUserAppResponse> Handle(GetTrainerFromUserAppRequest request, CancellationToken cancellationToken)
+    public async Task<GetTrainerFromUserAppResponse> Handle(GetTrainerFromUserAppRequest query,
+        CancellationToken cancellationToken)
     {
-        GetTrainerFromUserAppResponse resp = new();
-        try
-        {
-            var userStrategy =  _userStrategyResolver.Resolve(request.ApplicationType!);
-            var user = await userStrategy.GetAsync(request.UserId!);
-            var linkedTrainer =
-                await _catalogContext.Trainers.FirstOrDefaultAsync(trainer => trainer.Identity.UserId == request.UserId, cancellationToken);
-            if (linkedTrainer is null)
-            {
-                linkedTrainer = new Trainer(Name.Create(user.FirstName, user.LastName).Value,
-                    TrainerIdentity.Create(user.UserId, Enumeration.FromDisplayName<ApplicationType>(user.ApplicationType)).Value,string.Empty, string.Empty,
-                    Language.Create("EN").Value);
-                await _catalogContext.Trainers.AddAsync(linkedTrainer, cancellationToken);
-                await _catalogContext.SaveChangesAsync(cancellationToken);
-            }
+        GetTrainerFromUserAppResponse response = new();
+        var userStrategy = _userStrategyResolver.Resolve(query.ApplicationType);
+        response.User = await userStrategy.GetAsync(query.UserId);
 
-            resp.Trainer = linkedTrainer;
-            resp.SetSuccess();
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e.ToString());
-            throw;
-        }
-        return resp;
+        if (response.User is null) throw new UserException(Errors.User.NotFound(query.UserId));
+
+        response.Trainer = await _context.Trainers.FirstOrDefaultAsync(trainer =>
+            trainer.Identity.UserId == query.UserId && trainer.Identity.ApplicationTypeId ==
+            query.ApplicationType.Id, cancellationToken);
+        response.SetSuccess();
+
+        return response;
     }
-}
-
-public class GetTrainerFromUserAppRequest : IRequest<GetTrainerFromUserAppResponse>
-{
-    public string UserId { get; init; } = null!;
-    public ApplicationType ApplicationType { get; init; } = null!;
 }
 
 public class GetTrainerFromUserAppResponse : ResponseBase
 {
     public Trainer? Trainer { get; set; }
+    public UserDto User { get; set; } = null!;
+}
+
+public class GetTrainerFromUserAppRequest : IRequest<GetTrainerFromUserAppResponse>
+{
+    public string UserId { get; set; } = null!;
+    public ApplicationType ApplicationType { get; set; } = null!;
 }

--- a/src/Smart.FA.Catalog.Core/Domain/Training/Training.cs
+++ b/src/Smart.FA.Catalog.Core/Domain/Training/Training.cs
@@ -40,15 +40,15 @@ public class Training : Entity, IAggregateRoot
     public Training
     (
         Trainer trainer
-        , TrainingDetailDto trainingDetail
+        , TrainingDetailDto detail
         , IEnumerable<TrainingType> types
         , IEnumerable<TrainingSlotNumberType> slotNumberTypes
         , IEnumerable<TrainingTargetAudience> targetAudiences
         , IEnumerable<TrainingTopic> topics
     )
     {
-        AddDetails(trainingDetail.Title!, trainingDetail.Goal!, trainingDetail.Methodology!,
-            Language.Create(trainingDetail.Language).Value);
+        AddDetails(detail.Title!, detail.Goal, detail.Methodology,
+            Language.Create(detail.Language).Value);
         SwitchTrainingTypes(types);
         SwitchTargetAudience(targetAudiences);
         SwitchSlotNumberType(slotNumberTypes);
@@ -139,7 +139,7 @@ public class Training : Entity, IAggregateRoot
         return Result.Success<Training, IEnumerable<Error>>(this);
     }
 
-    public void AddDetails(string title, string goal, string methodology, Language language)
+    public void AddDetails(string title, string? goal, string? methodology, Language language)
     {
         Guard.AgainstNull(title, nameof(title));
         Guard.Requires(() => _details.FirstOrDefault(detail => detail.Language.Value == language.Value) == null,

--- a/src/Smart.FA.Catalog.Core/Exceptions/Error.cs
+++ b/src/Smart.FA.Catalog.Core/Exceptions/Error.cs
@@ -86,5 +86,14 @@ namespace Core.Exceptions
             public static Error GuardClauseBlockage(string message) => new("guard.clause.blockage", message);
 
         }
+
+        public static class User
+        {
+            public static Error NotFound(string? id = null)
+            {
+                var forId = id == null ? "" : $" for Id '{id}'";
+                return new Error("user.not.found", $"User not found{forId}");
+            }
+        }
     }
 }

--- a/src/Smart.FA.Catalog.Core/Exceptions/UserException.cs
+++ b/src/Smart.FA.Catalog.Core/Exceptions/UserException.cs
@@ -1,0 +1,10 @@
+using Core.SeedWork;
+
+namespace Core.Exceptions;
+
+public class UserException: DomainException
+{
+    public UserException(Error error) : base(error)
+    {
+    }
+}

--- a/src/Smart.FA.Catalog.Web/Extensions/Middlewares/ProxyHeaderMiddleware.cs
+++ b/src/Smart.FA.Catalog.Web/Extensions/Middlewares/ProxyHeaderMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Security.Principal;
+using Application.UseCases.Commands;
 using Application.UseCases.Queries;
 using Core.Domain.Enumerations;
 using Core.Domain.Models;
@@ -8,6 +9,11 @@ using MediatR;
 
 namespace Web.Extensions.Middlewares;
 
+/// <summary>
+/// The authentication is working with a system from Nginx (the proxy in front of our apps) called x-accel (https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/).
+/// The proxy header middleware parse incoming request from nginx to fetch a user and the name of the application the call originated.
+/// It will then proceed to log the user as a trainer for the rest of the request lifetime.
+/// </summary>
 public class ProxyHeaderMiddleware
 {
     private readonly RequestDelegate _next;
@@ -19,15 +25,22 @@ public class ProxyHeaderMiddleware
 
     public async Task InvokeAsync(HttpContext context, IMediator mediator )
     {
-
+        //Default values are used to substitute to the Nginx authentication system
+        //TODO: When the nginx authentication system is in place in every environment, remove default values
         var userId = (string.IsNullOrEmpty(context.Request.Headers["user_id"].ToString())  ? "1" : context.Request.Headers["user_id"].ToString())!;
-        var appName =  string.IsNullOrEmpty(context.Request.Headers["app_name"].ToString()) ? ApplicationType.Default.Name : context.Request.Headers["app_name"].ToString();
+        var appName =  string.IsNullOrEmpty(context.Request.Headers["app_name"].ToString()) ? ApplicationType.Account.Name : context.Request.Headers["app_name"].ToString();
         var applicationType = Enumeration.FromDisplayName<ApplicationType>(appName);
 
-        var resp = await mediator.Send(new GetTrainerFromUserAppRequest {UserId = userId, ApplicationType = applicationType});
+        var response = await mediator.Send(new GetTrainerFromUserAppRequest {UserId = userId, ApplicationType = applicationType});
 
-        CultureInfo.CurrentUICulture = new CultureInfo(resp.Trainer!.DefaultLanguage.Value);
-        context.User = new GenericPrincipal(new CustomIdentity(resp.Trainer!), null );
+        if (response.Trainer is null)
+        {
+            var newTrainerResponse = await mediator.Send(new CreateTrainerFromUserAppRequest{User = response.User});
+            response.Trainer = newTrainerResponse.Trainer;
+        }
+
+        CultureInfo.CurrentUICulture = new CultureInfo(response.Trainer!.DefaultLanguage.Value);
+        context.User = new GenericPrincipal(new CustomIdentity(response.Trainer!), null );
         await _next(context);
     }
 }


### PR DESCRIPTION
Separate fetching an user and its potential linked trainer from the user id and from creating the trainer if no trainer is linked to an userId/applicationtypeid in order to have a good command/query division (queries should not update data)