### PR TITLE
Use MediatR to handle publishing of domain events

### DIFF
--- a/src/Smart.FA.Catalog.Core/LogEvents/GeneralLogEvents.cs
+++ b/src/Smart.FA.Catalog.Core/LogEvents/GeneralLogEvents.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Smart.FA.Catalog.Core.LogEvents;
 
@@ -6,4 +6,6 @@ public static partial class LogEventIds
 {
     public static EventId DuplicateEventId = new(00001, nameof(DuplicateEventId));
     public static EventId ErrorEventId = new(00002, nameof(ErrorEventId));
+
+    public static readonly EventId DomainEventDispatch = new(0_003, nameof(DomainEventDispatch));
 }

--- a/src/Smart.FA.Catalog.Core/SeedWork/DomainEvent.cs
+++ b/src/Smart.FA.Catalog.Core/SeedWork/DomainEvent.cs
@@ -2,12 +2,12 @@ using MediatR;
 
 namespace Smart.FA.Catalog.Core.SeedWork;
 
-public abstract class DomainEvent : INotification
+public abstract class DomainEvent : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}
+
+public interface IDomainEvent : INotification
 {
     public DateTime OccurredAt { get; }
-
-    protected DomainEvent()
-    {
-        OccurredAt = DateTime.Now;
-    }
 }

--- a/src/Smart.FA.Catalog.Core/SeedWork/Entity.cs
+++ b/src/Smart.FA.Catalog.Core/SeedWork/Entity.cs
@@ -6,7 +6,7 @@ public abstract class Entity
 {
     #region Fields
 
-    private List<DomainEvent> _domainEvents = new();
+    private readonly List<IDomainEvent> _domainEvents = new();
 
     #endregion
 
@@ -16,15 +16,20 @@ public abstract class Entity
     public virtual bool IsTransient => Id == default;
     public DateTime CreatedAt { get; set; }
     public DateTime LastModifiedAt { get; set; }
-    public IReadOnlyCollection<DomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
     #endregion
 
     #region Public Methods
 
-    public void AddDomainEvent(DomainEvent @event)
+    public void AddDomainEvent(IDomainEvent @event)
     {
         _domainEvents.Add(@event);
+    }
+
+    public void RemoveDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Remove(domainEvent);
     }
 
     public void ClearDomainEvents()

--- a/src/Smart.FA.Catalog.Core/SeedWork/IDomainEventPublisher.cs
+++ b/src/Smart.FA.Catalog.Core/SeedWork/IDomainEventPublisher.cs
@@ -1,0 +1,14 @@
+namespace Smart.FA.Catalog.Core.SeedWork;
+
+public interface IDomainEventPublisher
+{
+    /// <summary>
+    /// Publishes every <paramref name="entities" />'s <see cref="IDomainEvent" />.
+    /// Each <see cref="IDomainEvent" /> published is removed from the entity to whom it belongs to.
+    /// This operation is not safe, this means that if any exception is raised during the process,
+    /// the execution will stop.
+    /// </summary>
+    /// <param name="entities">The entities whose domain events needs to be published.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public Task PublishEntitiesEventsAsync(IEnumerable<Entity> entities);
+}

--- a/src/Smart.FA.Catalog.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Smart.FA.Catalog.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -29,19 +29,16 @@ public static class ServiceCollectionExtensions
     )
     {
         services
-            .AddEventDispatcher()
+            .AddEventPublisher()
             .AddRepositories()
             .AddServices(userAccountConnectionString, mailOptionSection)
             .AddQueries(catalogConnectionString)
             .AddDbContext(catalogConnectionString, dalOptionSection);
     }
 
-    private static IServiceCollection AddEventDispatcher(this IServiceCollection services)
+    private static IServiceCollection AddEventPublisher(this IServiceCollection services)
     {
-        services.AddScoped<IBus, Bus>();
-        services.AddScoped<MessageBus>();
-        services.AddScoped<EventDispatcher>();
-        return services;
+        return services.AddScoped<IDomainEventPublisher, DomainEventPublisher>();
     }
 
     private static IServiceCollection AddServices(this IServiceCollection services, string userAccountConnectionString,

--- a/src/Smart.FA.Catalog.Infrastructure/Services/DomainEventPublisher.cs
+++ b/src/Smart.FA.Catalog.Infrastructure/Services/DomainEventPublisher.cs
@@ -1,0 +1,34 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Smart.FA.Catalog.Core.LogEvents;
+using Smart.FA.Catalog.Core.SeedWork;
+
+namespace Smart.FA.Catalog.Infrastructure.Services;
+
+public class DomainEventPublisher : IDomainEventPublisher
+{
+    private readonly ILogger<DomainEventPublisher> _logger;
+    private readonly IPublisher _publisher;
+
+    public DomainEventPublisher(ILogger<DomainEventPublisher> logger, IPublisher publisher)
+    {
+        _logger    = logger;
+        _publisher = publisher;
+    }
+
+    /// <inheritdoc />
+    public async Task PublishEntitiesEventsAsync(IEnumerable<Entity> entities)
+    {
+        foreach (var entity in entities)
+        {
+            foreach (var domainEvent in entity.DomainEvents)
+            {
+                _logger.LogInformation(LogEventIds.DomainEventDispatch, $"Publishing domain event {domainEvent.GetType().Name} of entity {entity.GetType().Name} `{entity.Id}`.");
+                await _publisher.Publish(domainEvent);
+                entity.RemoveDomainEvent(domainEvent);
+            }
+
+            _logger.LogInformation(LogEventIds.DomainEventDispatch, $"Domain events publishing of entity {entity.GetType().Name} `{entity.Id}` completed with success.");
+        }
+    }
+}


### PR DESCRIPTION
MediatR has its own memory bus and makes it easy in an elegant way to create code that handles event publishing.
The event publishing happens now after the database transaction. This avoids scenarios such mail being sent upon the creation of something but the database transaction actually failed.
However, in a future we would like to have the handling happening within the database transaction.

This PR introduces:

- A new type and interface for domain events
- Uses MediatR for the actual event publishing
- Update MediatR library to latest version (10.0)