### PR TITLE
Fix side menu not selected upon training edition failure

### DIFF
--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
@@ -35,6 +35,7 @@ public class UpdateModel : AdminPage
         var user = (HttpContext.User.Identity as CustomIdentity)!;
         if (!ModelState.IsValid)
         {
+            Init();
             return Page();
         }
 


### PR DESCRIPTION
When a post failure happens we need to call the method that initializes the page.
That is why the side menu was no longer selected correctly.