### PR TITLE
Prevent a internal error when accessing the edition of a non-existent training

### DIFF
--- a/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainingFromIdQueryHandler.cs
+++ b/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainingFromIdQueryHandler.cs
@@ -16,6 +16,7 @@ public class GetTrainingFromIdQueryHandler: IRequestHandler<GetTrainingFromIdReq
         _logger = logger;
         _catalogContext = catalogContext;
     }
+
     public async Task<GetTrainingFromIdResponse> Handle(GetTrainingFromIdRequest request, CancellationToken cancellationToken)
     {
         GetTrainingFromIdResponse resp = new();

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
@@ -20,14 +20,22 @@ public class UpdateModel : AdminPage
         SetSideMenuItem();
     }
 
-    public async Task OnGet(int id)
+    public async Task<ActionResult> OnGet(int id)
     {
         var user = (HttpContext.User.Identity as CustomIdentity)!;
         TrainingId = id;
-        var response =
-            await Mediator.Send(new GetTrainingFromIdRequest {TrainingId = TrainingId}, CancellationToken.None);
+        var response = await Mediator.Send(new GetTrainingFromIdRequest {TrainingId = TrainingId}, CancellationToken.None);
+
+        // We need to check if Training is not null otherwise MapToGetResponse will throw an exception.
+        if (response.Training is null)
+        {
+            return NotFound();
+        }
+
         UpdateTrainingViewModel = response.MapGetToResponse(user.Trainer.DefaultLanguage);
         Init();
+
+        return Page();
     }
 
     public async Task<IActionResult> OnPostUpdateAsync(int id)

--- a/src/Smart.FA.Catalog.Web/Program.cs
+++ b/src/Smart.FA.Catalog.Web/Program.cs
@@ -72,17 +72,9 @@ if (app.Environment.IsProduction())
 else
 {
     app.UseDeveloperExceptionPage();
+    app.UseStatusCodePagesWithReExecute("/{0}");
 }
 
-app.Use(async (context, next) =>
-{
-    await next();
-    if (context.Response.StatusCode == 404)
-    {
-        context.Request.Path = "/404";
-        await next();
-    }
-});
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
Putting an ID that does not exist in the browser would result in an internal error: null reference exception.