### PR TITLE
Prevent internal error when editing a training

### DIFF
--- a/src/Smart.FA.Catalog.Infrastructure/Persistence/Write/TrainingRepository.cs
+++ b/src/Smart.FA.Catalog.Infrastructure/Persistence/Write/TrainingRepository.cs
@@ -32,6 +32,7 @@ public class TrainingRepository : ITrainingRepository
             .Include(training => training.Identities)
             .Include(training => training.Slots)
             .Include(training => training.Targets)
+            .Include(training => training.Topics)
             .FirstOrDefaultAsync(training => training.Id == trainingId, cancellationToken);
 
     public async Task<Training> FindAsync(int trainingId, CancellationToken cancellationToken)

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/UpdateTrainingViewModel.cs
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/UpdateTrainingViewModel.cs
@@ -51,7 +51,8 @@ public static class EditTrainingViewModelMapping
             Methodology = detail?.Methodology,
             TargetAudienceIds = model.Training.Targets.Select(target => target.TrainingTargetAudienceId).ToList(),
             TrainingTypeIds = model.Training.Identities.Select(identity => identity.TrainingTypeId).ToList(),
-            SlotNumberTypeIds = model.Training.Slots.Select(slot => slot.TrainingSlotTypeId).ToList()
+            SlotNumberTypeIds = model.Training.Slots.Select(slot => slot.TrainingSlotTypeId).ToList(),
+            TopicIds = model.Training.Topics.Select(topic => topic.TrainingTopicId).ToList()
         };
 
         return response;


### PR DESCRIPTION
Because the topics were not correctly loaded, they were never cleared correctly during the save.
This resulted into a duplication primary sql error.
Making them tracked corrects the problem.
Also made sure to include the topic's ids in the view model of the page otherwise the existing topic are not checked.