### PR TITLE
Ignore DotSettings files generated by Resharper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+*.csproj.DotSettings
 
 # TeamCity is a build add-in
 _TeamCity*


### PR DESCRIPTION
Resharper generates a configuration file when enabling some features on projects.
Enabling support for string localization generates this kind of file.

Example:
```xml
<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
    <s:String x:Key="/Default/CodeEditing/Localization/Localizable/@EntryValue">Yes</s:String>
    <s:String x:Key="/Default/CodeEditing/Localization/LocalizableInspector/@EntryValue">Pessimistic</s:String>
</wpf:ResourceDictionary>
`