### PR TITLE
Add support to the user profile page to specify an email

### DIFF
--- a/src/Smart.FA.Catalog.Application/Extensions/FluentValidation/OnStringRuleBuilderExtensions.cs
+++ b/src/Smart.FA.Catalog.Application/Extensions/FluentValidation/OnStringRuleBuilderExtensions.cs
@@ -6,8 +6,8 @@ namespace Smart.FA.Catalog.Application.Extensions.FluentValidation;
 public static class OnStringRuleBuilderExtensions
 {
     /// <summary>
-    /// Defines a rules to validate a email format.
-    /// THe rule checks if the email is null or empty, then validates the format of the email.
+    /// Defines a rules to validate an email format.
+    /// The rule checks if the email is null or empty, then validates the format of the email.
     /// </summary>
     /// <typeparam name="T">Type of the object being validated.</typeparam>
     /// <param name="ruleBuilder">The <see cref="IRuleBuilder{T,TProperty}" /> on which is applied the rule.</param>

--- a/src/Smart.FA.Catalog.Application/Extensions/FluentValidation/OnStringRuleBuilderExtensions.cs
+++ b/src/Smart.FA.Catalog.Application/Extensions/FluentValidation/OnStringRuleBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using Smart.FA.Catalog.Core.Helpers;
+
+namespace Smart.FA.Catalog.Application.Extensions.FluentValidation;
+
+public static class OnStringRuleBuilderExtensions
+{
+    /// <summary>
+    /// Defines a rules to validate a email format.
+    /// THe rule checks if the email is null or empty, then validates the format of the email.
+    /// </summary>
+    /// <typeparam name="T">Type of the object being validated.</typeparam>
+    /// <param name="ruleBuilder">The <see cref="IRuleBuilder{T,TProperty}" /> on which is applied the rule.</param>
+    /// <returns>The source builder source, namely <paramref name="ruleBuilder" />.</returns>
+    public static IRuleBuilder<T, string?> ValidEmail<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithMessage(CatalogResources.EmailIsRequired)
+            .Must(email => EmailValidator.Validate(email))
+            .WithMessage(CatalogResources.InvalidEmail);
+    }
+}

--- a/src/Smart.FA.Catalog.Application/UseCases/Commands/EditProfileCommand.cs
+++ b/src/Smart.FA.Catalog.Application/UseCases/Commands/EditProfileCommand.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Smart.FA.Catalog.Application.Extensions.FluentValidation;
 using Smart.FA.Catalog.Application.SeedWork;
 using Smart.FA.Catalog.Core.Domain;
 using Smart.FA.Catalog.Core.Domain.Enumerations;
@@ -23,6 +24,8 @@ public class EditProfileCommand : IRequest<ProfileEditionResponse>
     public string? Title { get; set; }
 
     public Dictionary<string, string>? Socials { get; set; }
+
+    public string? Email { get; set; }
 }
 
 public class EditProfileCommandHandler : IRequestHandler<EditProfileCommand, ProfileEditionResponse>
@@ -90,6 +93,7 @@ public class EditProfileCommandHandler : IRequestHandler<EditProfileCommand, Pro
     {
         trainer.UpdateBiography(command.Bio ?? string.Empty);
         trainer.UpdateTitle(command.Title ?? string.Empty);
+        trainer.ChangeEmail(command.Email);
         foreach (var commandSocial in command.Socials!)
         {
             var socialNetwork = Enumeration.FromValue<SocialNetwork>(int.Parse(commandSocial.Key));
@@ -147,5 +151,8 @@ public class EditProfileCommandValidator : AbstractValidator<EditProfileCommand>
             .WithMessage(CatalogResources.BioMustBe30Chars)
             .MaximumLength(500)
             .WithMessage(CatalogResources.BioCannotExceed500Chars);
+
+        RuleFor(command => command.Email)
+            .ValidEmail();
     }
 }

--- a/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainerProfileQuery.cs
+++ b/src/Smart.FA.Catalog.Application/UseCases/Queries/GetTrainerProfileQuery.cs
@@ -62,6 +62,7 @@ public class GetTrainerProfileQueryHandler : IRequestHandler<GetTrainerProfileQu
                 Bio       = trainer.Biography,
                 Name      = trainer.Name.FirstName + " " + trainer.Name.LastName,
                 Title     = trainer.Title,
+                Email     = trainer.Email,
                 Socials   = trainer.PersonalSocialNetworks
             }).FirstOrDefaultAsync(trainer => trainer.TrainerId == query.TrainerId, cancellationToken);
 
@@ -72,6 +73,7 @@ public class GetTrainerProfileQueryHandler : IRequestHandler<GetTrainerProfileQu
                 Bio       = trainer.Bio,
                 Name      = trainer.Name,
                 Title     = trainer.Title,
+                Email     = trainer.Email,
                 Socials   = trainer.Socials.ToTrainerProfileSocials()
             }
             : null;
@@ -87,6 +89,8 @@ public class TrainerProfile
     public string? Name { get; set; }
 
     public string? Title { get; set; }
+
+    public string? Email { get; set; }
 
     public IEnumerable<Social> Socials { get; set; } = null!;
 

--- a/src/Smart.FA.Catalog.Core/Domain/Trainer/Trainer.cs
+++ b/src/Smart.FA.Catalog.Core/Domain/Trainer/Trainer.cs
@@ -18,7 +18,10 @@ public class Trainer : Entity, IAggregateRoot
     public virtual Name Name { get; private set; } = null!;
 
     public string Biography { get; private set; } = null!;
-    public string Title { get; set; } = null!;
+
+    public string Title { get; private set; } = null!;
+
+    public string? Email { get; private set; }
 
     public Language DefaultLanguage { get; private set; } = null!;
 
@@ -82,6 +85,7 @@ public class Trainer : Entity, IAggregateRoot
         => Assignments.Any() ? Assignments.Select(assignment => assignment.Training).ToList() : new List<Training>();
 
     public void Rename(Name name) => Name = name;
+
     public void ChangeDefaultLanguage(Language language) => DefaultLanguage = language;
 
     /// <summary>
@@ -108,6 +112,17 @@ public class Trainer : Entity, IAggregateRoot
         {
             _personalSocialNetworks.Add(new PersonalSocialNetwork(Id, socialNetwork, urlToProfile));
         }
+    }
+
+    /// <summary>
+    /// Changes the <see cref="Trainer" />'s email address.
+    /// </summary>
+    /// <param name="email">The new email.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="email" /> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="email" />'s format is invalid.</exception>
+    public void ChangeEmail(string? email)
+    {
+        Email = Guard.AgainstInvalidEmail(email, nameof(email));
     }
 
     #endregion

--- a/src/Smart.FA.Catalog.Core/Helpers/EmailValidator.cs
+++ b/src/Smart.FA.Catalog.Core/Helpers/EmailValidator.cs
@@ -1,0 +1,446 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using FluentValidation.Validators;
+
+namespace Smart.FA.Catalog.Core.Helpers;
+
+//
+// EmailValidator.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2022 Jeffrey Stedfast
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/// <summary>
+/// An Email validator.
+/// </summary>
+/// <remarks>
+/// An Email validator.
+/// </remarks>
+public static class EmailValidator
+{
+    const string AtomCharacters = "!#$%&'*+-/=?^_`{|}~";
+
+    [Flags]
+    enum SubDomainType
+    {
+        None = 0,
+        Alphabetic = 1,
+        Numeric = 2,
+        AlphaNumeric = 3
+    }
+
+    static bool IsControl(char c)
+    {
+        return c <= 31 || c == 127;
+    }
+
+    static bool IsDigit(char c)
+    {
+        return (c >= '0' && c <= '9');
+    }
+
+    static bool IsLetter(char c)
+    {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    static bool IsLetterOrDigit(char c)
+    {
+        return IsLetter(c) || IsDigit(c);
+    }
+
+    static bool IsAtom(char c, bool allowInternational)
+    {
+        // check for control characters
+        if (IsControl(c))
+            return false;
+
+        return c < 128 ? IsLetterOrDigit(c) || AtomCharacters.IndexOf(c) != -1 : allowInternational;
+    }
+
+    static bool IsDomain(char c, bool allowInternational, ref SubDomainType type)
+    {
+        if (c < 128)
+        {
+            if (IsLetter(c) || c == '-')
+            {
+                type |= SubDomainType.Alphabetic;
+                return true;
+            }
+
+            if (IsDigit(c))
+            {
+                type |= SubDomainType.Numeric;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (allowInternational)
+        {
+            type |= SubDomainType.Alphabetic;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsDomainStart(char c, bool allowInternational, out SubDomainType type)
+    {
+        if (c < 128)
+        {
+            if (IsLetter(c))
+            {
+                type = SubDomainType.Alphabetic;
+                return true;
+            }
+
+            if (IsDigit(c))
+            {
+                type = SubDomainType.Numeric;
+                return true;
+            }
+
+            type = SubDomainType.None;
+
+            return false;
+        }
+
+        if (allowInternational)
+        {
+            type = SubDomainType.Alphabetic;
+            return true;
+        }
+
+        type = SubDomainType.None;
+
+        return false;
+    }
+
+    static bool SkipAtom(string text, ref int index, bool allowInternational)
+    {
+        int startIndex = index;
+
+        while (index < text.Length && IsAtom(text[index], allowInternational))
+            index++;
+
+        return index > startIndex;
+    }
+
+    static bool SkipSubDomain(string text, ref int index, bool allowInternational, out SubDomainType type)
+    {
+        int startIndex = index;
+
+        if (!IsDomainStart(text[index], allowInternational, out type))
+            return false;
+
+        index++;
+
+        while (index < text.Length && IsDomain(text[index], allowInternational, ref type))
+            index++;
+
+        // Don't allow single-character top-level domains.
+        if (index == text.Length && (index - startIndex) == 1)
+            return false;
+
+        // https://datatracker.ietf.org/doc/html/rfc2181#section-11
+        // The length of any one label is limited to between 1 and 63 octets. A full domain
+        // name is limited to 255 octets (including the separators).
+        return (index - startIndex) < 64 && text[index - 1] != '-';
+    }
+
+    static bool SkipDomain(string text, ref int index, bool allowTopLevelDomains, bool allowInternational)
+    {
+        if (!SkipSubDomain(text, ref index, allowInternational, out var type))
+            return false;
+
+        if (index < text.Length && text[index] == '.')
+        {
+            do
+            {
+                index++;
+
+                if (index == text.Length)
+                    return false;
+
+                if (!SkipSubDomain(text, ref index, allowInternational, out type))
+                    return false;
+            } while (index < text.Length && text[index] == '.');
+        }
+        else if (!allowTopLevelDomains)
+        {
+            return false;
+        }
+
+        // Note: by allowing AlphaNumeric, we get away with not having to support punycode.
+        if (type == SubDomainType.Numeric)
+            return false;
+
+        return true;
+    }
+
+    static bool SkipQuoted(string text, ref int index, bool allowInternational)
+    {
+        bool escaped = false;
+
+        // skip over leading '"'
+        index++;
+
+        while (index < text.Length)
+        {
+            if (IsControl(text[index]) || (text[index] >= 128 && !allowInternational))
+                return false;
+
+            if (text[index] == '\\')
+            {
+                escaped = !escaped;
+            }
+            else if (!escaped)
+            {
+                if (text[index] == '"')
+                    break;
+            }
+            else
+            {
+                escaped = false;
+            }
+
+            index++;
+        }
+
+        if (index >= text.Length || text[index] != '"')
+            return false;
+
+        index++;
+
+        return true;
+    }
+
+    static bool SkipIPv4Literal(string text, ref int index)
+    {
+        int groups = 0;
+
+        while (index < text.Length && groups < 4)
+        {
+            int startIndex = index;
+            int value = 0;
+
+            while (index < text.Length && IsDigit(text[index]))
+            {
+                value = (value * 10) + (text[index] - '0');
+                index++;
+            }
+
+            if (index == startIndex || index - startIndex > 3 || value > 255)
+                return false;
+
+            groups++;
+
+            if (groups < 4 && index < text.Length && text[index] == '.')
+                index++;
+        }
+
+        return groups == 4;
+    }
+
+    static bool IsHexDigit(char c)
+    {
+        return (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f') || (c >= '0' && c <= '9');
+    }
+
+    // This needs to handle the following forms:
+    //
+    // IPv6-addr = IPv6-full / IPv6-comp / IPv6v4-full / IPv6v4-comp
+    // IPv6-hex  = 1*4HEXDIG
+    // IPv6-full = IPv6-hex 7(":" IPv6-hex)
+    // IPv6-comp = [IPv6-hex *5(":" IPv6-hex)] "::" [IPv6-hex *5(":" IPv6-hex)]
+    //             ; The "::" represents at least 2 16-bit groups of zeros
+    //             ; No more than 6 groups in addition to the "::" may be
+    //             ; present
+    // IPv6v4-full = IPv6-hex 5(":" IPv6-hex) ":" IPv4-address-literal
+    // IPv6v4-comp = [IPv6-hex *3(":" IPv6-hex)] "::"
+    //               [IPv6-hex *3(":" IPv6-hex) ":"] IPv4-address-literal
+    //             ; The "::" represents at least 2 16-bit groups of zeros
+    //             ; No more than 4 groups in addition to the "::" and
+    //             ; IPv4-address-literal may be present
+    static bool SkipIPv6Literal(string text, ref int index)
+    {
+        bool needGroup = false;
+        bool compact = false;
+        int groups = 0;
+
+        while (index < text.Length)
+        {
+            int startIndex = index;
+
+            while (index < text.Length && IsHexDigit(text[index]))
+                index++;
+
+            if (index >= text.Length)
+                break;
+
+            if (index > startIndex && text[index] == '.' && (compact || groups == 6))
+            {
+                // IPv6v4
+                index = startIndex;
+
+                if (!SkipIPv4Literal(text, ref index))
+                    return false;
+
+                return compact ? groups <= 4 : groups == 6;
+            }
+
+            int count = index - startIndex;
+            if (count > 4)
+                return false;
+
+            if (count > 0)
+            {
+                needGroup = false;
+                groups++;
+            }
+
+            if (text[index] != ':')
+                break;
+
+            startIndex = index;
+            while (index < text.Length && text[index] == ':')
+                index++;
+
+            count = index - startIndex;
+            if (count > 2)
+                return false;
+
+            if (count == 2)
+            {
+                if (compact)
+                    return false;
+
+                compact = true;
+            }
+            else
+            {
+                needGroup = true;
+            }
+        }
+
+        return !needGroup && (compact ? groups <= 6 : groups == 8);
+    }
+
+    /// <summary>
+    /// Validate the specified email address.
+    /// </summary>
+    /// <remarks>
+    /// <para>Validates the syntax of an email address.</para>
+    /// <para>If <paramref name="allowTopLevelDomains"/> is <c>true</c>, then the validator will
+    /// allow addresses with top-level domains like <c>postmaster@dk</c>.</para>
+    /// <para>If <paramref name="allowInternational"/> is <c>true</c>, then the validator
+    /// will use the newer International Email standards for validating the email address.</para>
+    /// </remarks>
+    /// <returns><c>true</c> if the email address is valid; otherwise, <c>false</c>.</returns>
+    /// <param name="email">An email address.</param>
+    /// <param name="allowTopLevelDomains"><c>true</c> if the validator should allow addresses at top-level domains; otherwise, <c>false</c>.</param>
+    /// <param name="allowInternational"><c>true</c> if the validator should allow international characters; otherwise, <c>false</c>.</param>
+    /// <exception cref="System.ArgumentNullException">
+    /// <paramref name="email"/> is <c>null</c>.
+    /// </exception>
+    public static bool Validate(string email, bool allowTopLevelDomains = false, bool allowInternational = false)
+    {
+        int index = 0;
+
+        if (email == null)
+            throw new ArgumentNullException(nameof(email));
+
+        if (email.Length == 0 || email.Length > 254)
+            return false;
+
+        // Local-part = Dot-string / Quoted-string
+        //       ; MAY be case-sensitive
+        //
+        // Dot-string = Atom *("." Atom)
+        //
+        // Quoted-string = DQUOTE *qcontent DQUOTE
+        if (email[index] == '"')
+        {
+            if (!SkipQuoted(email, ref index, allowInternational) || index >= email.Length)
+                return false;
+        }
+        else
+        {
+            if (!SkipAtom(email, ref index, allowInternational) || index >= email.Length)
+                return false;
+
+            while (email[index] == '.')
+            {
+                index++;
+
+                if (index >= email.Length)
+                    return false;
+
+                if (!SkipAtom(email, ref index, allowInternational))
+                    return false;
+
+                if (index >= email.Length)
+                    return false;
+            }
+        }
+
+        // https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1
+        // The maximum total length of a user name or other local-part is 64 octets.
+        if (index + 1 >= email.Length || index > 64 || email[index++] != '@')
+            return false;
+
+        if (email[index] != '[')
+        {
+            // domain
+            if (!SkipDomain(email, ref index, allowTopLevelDomains, allowInternational))
+                return false;
+
+            return index == email.Length;
+        }
+
+        // address literal
+        index++;
+
+        // We need at least 7 more characters. "1.1.1.1" and "IPv6:::" are the shortest literals we can have.
+        if (index + 7 >= email.Length)
+            return false;
+
+        if (string.Compare(email, index, "IPv6:", 0, 5, StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            index += "IPv6:".Length;
+            if (!SkipIPv6Literal(email, ref index))
+                return false;
+        }
+        else
+        {
+            if (!SkipIPv4Literal(email, ref index))
+                return false;
+        }
+
+        if (index >= email.Length || email[index++] != ']')
+            return false;
+
+        return index == email.Length;
+    }
+}

--- a/src/Smart.FA.Catalog.Core/SeedWork/Guard.cs
+++ b/src/Smart.FA.Catalog.Core/SeedWork/Guard.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Smart.FA.Catalog.Core.Exceptions;
+using Smart.FA.Catalog.Core.Helpers;
 
 namespace Smart.FA.Catalog.Core.SeedWork;
 
@@ -21,5 +22,16 @@ public static class Guard
     {
         if (argumentValue is null)
             throw new ArgumentNullException(argumentName);
+    }
+
+    public static string AgainstInvalidEmail(string? email, string parameter, string? message = null)
+    {
+        AgainstNull(email, parameter);
+        if (!EmailValidator.Validate(email!))
+        {
+            throw new ArgumentException(message ?? $"{email} is an invalid email", parameter);
+        }
+
+        return email!;
     }
 }

--- a/src/Smart.FA.Catalog.Core/SeedWork/Guard.cs
+++ b/src/Smart.FA.Catalog.Core/SeedWork/Guard.cs
@@ -24,12 +24,12 @@ public static class Guard
             throw new ArgumentNullException(argumentName);
     }
 
-    public static string AgainstInvalidEmail(string? email, string parameter, string? message = null)
+    public static string AgainstInvalidEmail(string? email, string parameterName, string? message = null)
     {
-        AgainstNull(email, parameter);
+        AgainstNull(email, parameterName);
         if (!EmailValidator.Validate(email!))
         {
-            throw new ArgumentException(message ?? $"{email} is an invalid email", parameter);
+            throw new ArgumentException(message ?? $"{email} is an invalid email", parameterName);
         }
 
         return email!;

--- a/src/Smart.FA.Catalog.Infrastructure/Migrations/20220325153842_Add_Email_To_Trainer.Designer.cs
+++ b/src/Smart.FA.Catalog.Infrastructure/Migrations/20220325153842_Add_Email_To_Trainer.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Smart.FA.Catalog.Infrastructure.Persistence;
 
@@ -11,9 +12,10 @@ using Smart.FA.Catalog.Infrastructure.Persistence;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(CatalogContext))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20220325153842_Add_Email_To_Trainer")]
+    partial class Add_Email_To_Trainer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Smart.FA.Catalog.Infrastructure/Migrations/20220325153842_Add_Email_To_Trainer.cs
+++ b/src/Smart.FA.Catalog.Infrastructure/Migrations/20220325153842_Add_Email_To_Trainer.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    public partial class Add_Email_To_Trainer : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "TrainingType",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Email",
+                table: "Trainer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "TrainingStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Name",
+                value: "PendingValidation");
+
+            migrationBuilder.UpdateData(
+                table: "TrainingTopic",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Name",
+                value: "HealthCare");
+
+            migrationBuilder.InsertData(
+                table: "TrainingTopic",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 8, "EconomyMarketing" },
+                    { 9, "Sport" }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "TrainingType",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Name",
+                value: "ScholarTraining");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "TrainingTopic",
+                keyColumn: "Id",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "TrainingTopic",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DropColumn(
+                name: "Email",
+                table: "Trainer");
+
+            migrationBuilder.UpdateData(
+                table: "TrainingStatus",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Name",
+                value: "WaitingForValidation");
+
+            migrationBuilder.UpdateData(
+                table: "TrainingTopic",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Name",
+                value: "Health");
+
+            migrationBuilder.UpdateData(
+                table: "TrainingType",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Name",
+                value: "SchoolCourse");
+
+            migrationBuilder.InsertData(
+                table: "TrainingType",
+                columns: new[] { "Id", "Name" },
+                values: new object[] { 4, "PermanentSchoolCourse" });
+        }
+    }
+}

--- a/src/Smart.FA.Catalog.Localization/CatalogResources.Designer.cs
+++ b/src/Smart.FA.Catalog.Localization/CatalogResources.Designer.cs
@@ -178,6 +178,15 @@ namespace Smart.FA.Catalog.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Un email est requis.
+        /// </summary>
+        public static string EmailIsRequired {
+            get {
+                return ResourceManager.GetString("EmailIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Salarié-es en entreprise et / ou indépendant-es.
         /// </summary>
         public static string Employee {
@@ -228,6 +237,15 @@ namespace Smart.FA.Catalog.Localization {
         public static string InformationTechnology {
             get {
                 return ResourceManager.GetString("InformationTechnology", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Email invalide.
+        /// </summary>
+        public static string InvalidEmail {
+            get {
+                return ResourceManager.GetString("InvalidEmail", resourceCulture);
             }
         }
         
@@ -331,7 +349,7 @@ namespace Smart.FA.Catalog.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Mon espace utilisateur.
         /// </summary>
         public static string MyUserSpace {
             get {

--- a/src/Smart.FA.Catalog.Localization/CatalogResources.resx
+++ b/src/Smart.FA.Catalog.Localization/CatalogResources.resx
@@ -349,4 +349,10 @@
   <data name="MyUserSpace" xml:space="preserve">
     <value>Mon espace utilisateur</value>
   </data>
+  <data name="EmailIsRequired" xml:space="preserve">
+    <value>Un email est requis</value>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>Email invalide</value>
+  </data>
 </root>

--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml
@@ -30,6 +30,7 @@
         <smart-grid>
             <smart-grid-column width="7">
                 <smart-panel header="@Model.UserIdentity.Identity.Name">
+                    <smart-form-group-input-text label="Email" asp-for="EditProfileCommand.Email"></smart-form-group-input-text>
                     <smart-form-group-input-text label="@CatalogResources.TrainerTitle" asp-for="EditProfileCommand.Title"></smart-form-group-input-text>
                     <smart-form-group-textarea rows="6" label="Bio" asp-for="EditProfileCommand.Bio" helper-text="@CatalogResources.Min30CharMax500Char"></smart-form-group-textarea>
                 </smart-panel>

--- a/src/Smart.FA.Catalog.Web/ViewModels/Trainers/ProfileViewModels.cs
+++ b/src/Smart.FA.Catalog.Web/ViewModels/Trainers/ProfileViewModels.cs
@@ -25,7 +25,8 @@ public static class Mappers
         {
             TrainerId = trainerProfile.TrainerId!.Value,
             Bio       = trainerProfile.Bio,
-            Title     = trainerProfile.Title
+            Title     = trainerProfile.Title,
+            Email     = trainerProfile.Email
         };
     }
 


### PR DESCRIPTION
This commit introduces the possibility for users to specify their email.
 * A new guard clause is added to validate emails.
 * A new rule builder extension on string to validate email has been added.
 * Imported [EmailValidator](https://github.com/jstedfast/EmailValidation/blob/master/EmailValidation/EmailValidator.cs) class, this make us independent of the NuGet.
 * The library passes the following  [tests](https://github.com/jstedfast/EmailValidation/blob/master/UnitTests/EmailValidationTests.cs)