### PR TITLE
Fix an issue where gap was missing between training tiles

### DIFF
--- a/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
+++ b/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
@@ -28,7 +28,7 @@
     </div>
 }
 
-<div>
+<div class="o-card-grid small-up-1">
     @foreach (var training in Model.Trainings!.GroupBy(training => training.TrainingId))
     {
         @await Component.InvokeAsync("AdminTrainingTile", new { model = training})


### PR DESCRIPTION
The class small-up-1 is required to produce margin between tiles of the 'My Training' listing view.