### PR TITLE
Add logging of commands and queries on development builds

### DIFF
--- a/src/Smart.FA.Catalog.Application/Models/Options/MediatROptions.cs
+++ b/src/Smart.FA.Catalog.Application/Models/Options/MediatROptions.cs
@@ -1,0 +1,8 @@
+namespace Smart.FA.Catalog.Application.Models.Options;
+
+public class MediatROptions
+{
+    public const string SectionName = "MediatR";
+
+    public bool LogRequests { get; set; }
+}

--- a/src/Smart.FA.Catalog.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Smart.FA.Catalog.Web/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Smart.FA.Catalog.Application.Models.Options;
 using Smart.FA.Catalog.Core.Services;
 using Smart.FA.Catalog.Web.Identity;
 using Smart.FA.Catalog.Web.Options;
@@ -6,15 +7,18 @@ namespace Smart.FA.Catalog.Web.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddApi(this IServiceCollection services, IConfigurationSection adminOptionsSection)
+    public static void AddApi(this IServiceCollection services, IConfiguration configuration)
     {
         services
             .AddScoped<IUserIdentity, UserIdentity>()
-            .AddOptions(adminOptionsSection);
+            .AddOptions(configuration);
     }
 
-    private static IServiceCollection AddOptions(this IServiceCollection services, IConfigurationSection adminOptionsSection)
+    private static IServiceCollection AddOptions(this IServiceCollection services, IConfiguration configuration)
     {
-        return services.Configure<AdminOptions>(adminOptionsSection);
+        services.Configure<AdminOptions>(configuration.GetSection(AdminOptions.SectionName));
+        services.Configure<MediatROptions>(configuration.GetSection(MediatROptions.SectionName));
+
+        return services;
     }
 }

--- a/src/Smart.FA.Catalog.Web/Options/AdminOptions.cs
+++ b/src/Smart.FA.Catalog.Web/Options/AdminOptions.cs
@@ -2,6 +2,8 @@ namespace Smart.FA.Catalog.Web.Options;
 
 public class AdminOptions
 {
+    public const string SectionName = "AdminOptions";
+
     public TrainingOptions? Training { get; set; }
 }
 

--- a/src/Smart.FA.Catalog.Web/Program.cs
+++ b/src/Smart.FA.Catalog.Web/Program.cs
@@ -21,8 +21,7 @@ builder.Services
 builder.Services
     .AddApplication();
 builder.Services
-    .AddApi(builder.Configuration
-        .GetSection("AdminOptions"));
+    .AddApi(builder.Configuration);
 builder.Services
     .AddSmartDesign();
 builder.Services

--- a/src/Smart.FA.Catalog.Web/appsettings.Development.json
+++ b/src/Smart.FA.Catalog.Web/appsettings.Development.json
@@ -20,5 +20,8 @@
     "Training": {
       "NumberOfTrainingsDisplayed": 3
     }
+  },
+  "MediatR": {
+    "LogRequests" : true
   }
 }

--- a/src/Smart.FA.Catalog.Web/appsettings.json
+++ b/src/Smart.FA.Catalog.Web/appsettings.json
@@ -12,8 +12,7 @@
     "Catalog": "Server=host.docker.internal; Database=Catalog; User Id =SA; Password=localStoragePassword!",
     "Account": "Server=host.docker.internal; Database=Account; User Id =SA; Password=localStoragePassword!"
   },
-  "MailOptions":
-  {
+  "MailOptions": {
     "Server": "",
     "Sender": ""
   },
@@ -21,5 +20,8 @@
     "Training": {
       "NumberOfTrainingsDisplayed": 3
     }
+  },
+  "MediatR": {
+    "LogRequests": false
   }
 }


### PR DESCRIPTION
This commit introduces a new application settings `LogRequests`.
When this settings is equal to true, the commands and queries are logged.
This setting is by default equal to false but on development build.

--------------
@Victor-van-Duijnen 
Something else I changed:
Note an IConfiguration object is sent to the AddApi extensions in place of an IConfigurationSection over the time the applcation settings will grow and ending with 3,4,5,6 + sections will eventually occur, I think it is better to pass direct one single object.