### PR TITLE
MediatR: when serializing requests prevent circular errors

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Development.json
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Development.json
@@ -36,7 +36,7 @@
     }
   },
   "MediatR": {
-    "LogRequests" : true
+    "LogRequests": true
   },
   "EFCore":
   {


### PR DESCRIPTION
The LoggingPipelineBehavior class logs in development environments requests that come in.
If the request has circular references, example, an entity, such Trainer, it will result with into an exception because it produces an infinite loop.

Internal Jira ticket: https://smartjira.atlassian.net/browse/CFA-290

Some doc: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-preserve-references?pivots=dotnet-6-0