### PR TITLE
Fix broken paging in training listing page

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
@@ -1,9 +1,41 @@
 namespace Smart.FA.Catalog.Core.Domain.Dto;
 
-public record TrainingDto
-    (int TrainingId,
-    short StatusId,
-    string Title,
-    string? Goal,
-    string Language,
-    int TopicId);
+//Because of some restrictions with Dapper*, we cannot use a record here
+//*Dapper split-on feature seems to only support a mutable list of topic ids in its constructor
+public class TrainingDto
+{
+    public int TrainingId { get; }
+    public short StatusId { get; }
+    public string Title { get; }
+    public string? Goal { get; }
+    public string Language { get; }
+    public List<int>? TopicIds { get; }
+
+    public TrainingDto(int trainingId,
+        short statusId,
+        string title,
+        string? goal,
+        string language,
+        List<int> topicIds)
+    {
+        TrainingId = trainingId;
+        StatusId = statusId;
+        Title = title;
+        Goal = goal;
+        Language = language;
+        TopicIds = topicIds;
+    }
+    public TrainingDto(int trainingId,
+        short statusId,
+        string title,
+        string? goal,
+        string Language)
+    {
+        this.TrainingId = trainingId;
+        this.StatusId = statusId;
+        this.Title = title;
+        this.Goal = goal;
+        this.Language = Language;
+        this.TopicIds = new List<int>();
+    }
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
@@ -25,17 +25,18 @@ public class TrainingDto
         Language = language;
         TopicIds = topicIds;
     }
+
     public TrainingDto(int trainingId,
         short statusId,
         string title,
         string? goal,
-        string Language)
+        string language)
     {
-        this.TrainingId = trainingId;
-        this.StatusId = statusId;
-        this.Title = title;
-        this.Goal = goal;
-        this.Language = Language;
-        this.TopicIds = new List<int>();
+        TrainingId = trainingId;
+        StatusId = statusId;
+        Title = title;
+        Goal = goal;
+        Language = language;
+        TopicIds = new List<int>();
     }
 }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Training/Dto/TrainingDto.cs
@@ -1,7 +1,7 @@
 namespace Smart.FA.Catalog.Core.Domain.Dto;
 
-//Because of some restrictions with Dapper*, we cannot use a record here
-//*Dapper split-on feature seems to only support a mutable list of topic ids in its constructor
+// Because of some restrictions with Dapper*, we cannot use a record here
+// *Dapper split-on feature seems to only support a mutable list of topic ids in its constructor
 public class TrainingDto
 {
     public int TrainingId { get; }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Persistence/Read/TrainingQueries.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Persistence/Read/TrainingQueries.cs
@@ -51,9 +51,19 @@ public class TrainingQueries : ITrainingQueries
                     INNER JOIN dbo.TrainingDetail TD ON T.Id = TD.TrainingId
                     WHERE TE.TrainerId = @TrainerId AND TD.Language = @Language ";
         await using var connection = new SqlConnection(_connectionString);
-        return await connection.QueryAsync<TrainingDto>(sql, new {trainerId, language});
+        return await connection.QueryAsync<TrainingDto, int?, TrainingDto>(sql, (dto, topicId) =>
+            {
+                if (topicId is not null)
+                {
+                    dto.TopicIds?.Add((int) topicId);
+                }
+                return dto;
+            },
+            splitOn: "TopicId",
+            param: new {trainerId, language});
     }
 
+    //TODO: it's a bit heavy for a simple paging system (though it works), we might want to look to refactor that at some point
     public async Task<PagedList<TrainingDto>> GetPagedListAsync(int trainerId, string language, PageItem pageItem,
         CancellationToken cancellationToken)
     {
@@ -64,29 +74,50 @@ public class TrainingQueries : ITrainingQueries
 	                    TD.Goal,
                         TD.Language,
                         TC.TrainingTopicId 'TopicId'
-                    FROM dbo.Training T
-                    INNER JOIN dbo.TrainerAssignment TE ON T.Id = TE.TrainingId
-                    LEFT JOIN dbo.TrainingCategory TC ON T.Id = TC.TrainingId
-                    INNER JOIN dbo.TrainingDetail TD ON T.Id = TD.TrainingId
-                    WHERE TE.TrainerId = @TrainerId AND TD.Language = @Language
-                    ORDER BY T.Id
-                    OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY";
-
-        var countsql = @"SELECT
-	                    COUNT(*)
-                    FROM dbo.Training T
+                    FROM (SELECT * FROM dbo.Training T ORDER BY T.Id
+                    OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY) T
                     INNER JOIN dbo.TrainerAssignment TE ON T.Id = TE.TrainingId
                     LEFT JOIN dbo.TrainingCategory TC ON T.Id = TC.TrainingId
                     INNER JOIN dbo.TrainingDetail TD ON T.Id = TD.TrainingId
                     WHERE TE.TrainerId = @TrainerId AND TD.Language = @Language";
 
+        var countsql = @"SELECT
+	                        COUNT(*)
+                        FROM (SELECT T.Id FROM dbo.Training T
+                        INNER JOIN dbo.TrainerAssignment TE ON T.Id = TE.TrainingId
+                        LEFT JOIN dbo.TrainingCategory TC ON T.Id = TC.TrainingId
+                        INNER JOIN dbo.TrainingDetail TD ON T.Id = TD.TrainingId
+                        WHERE TE.TrainerId = @TrainerId AND TD.Language = @Language
+                        GROUP BY T.Id) A";
+
         await using var connection = new SqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken);
         await using var transaction = connection.BeginTransaction();
+
+        //Fetch the count of distinct trainings
         var count = await transaction.QuerySingleAsync<int>(countsql, new {trainerId, language});
-        var list = await transaction.QueryAsync<TrainingDto>(sql,
-            new {trainerId, language, pageItem.Offset, pageItem.PageSize});
+        //Get a list of training and splits field on the training topic id
+        var list = await transaction.QueryAsync<TrainingDto, int?, TrainingDto>(sql, (dto, topicId) =>
+            {
+                if (topicId is not null)
+                {
+                    dto.TopicIds?.Add((int) topicId);
+                }
+
+                return dto;
+            },
+            splitOn: "TopicId",
+            param: new {trainerId, language, pageItem.Offset, pageItem.PageSize});
         transaction.Commit();
-        return new PagedList<TrainingDto>(list, pageItem, count);
+        //Regroup all training records by id
+        var result = list.GroupBy(dto => dto.TrainingId).Select(trainingGroup =>
+            new TrainingDto(trainingGroup.Key,
+                trainingGroup.First().StatusId,
+                trainingGroup.First().Title,
+                trainingGroup.First().Goal,
+                trainingGroup.First().Language,
+                trainingGroup.SelectMany(tg => tg.TopicIds).ToList()));
+
+        return new PagedList<TrainingDto>(result, pageItem, count);
     }
 }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
@@ -1,5 +1,7 @@
 ﻿@page
 @using Microsoft.Extensions.Localization
+@using Smart.FA.Catalog.Core.Domain.Dto
+@using Smart.FA.Catalog.Core.SeedWork
 @inject IStringLocalizer<CatalogResources> _localizer
 @model Smart.FA.Catalog.Web.Pages.Admin.Trainings.List.ListModel
 @{
@@ -29,7 +31,7 @@
 }
 
 <div class="o-card-grid small-up-1">
-    @foreach (var training in Model.Trainings!.GroupBy(training => training.TrainingId))
+    @foreach (var training in Model.Trainings!)
     {
         @await Component.InvokeAsync("AdminTrainingTile", new { model = training})
     }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/AdminTrainingCardViewComponent.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/AdminTrainingCardViewComponent.cs
@@ -6,7 +6,7 @@ namespace Smart.FA.Catalog.Web.Pages.Shared.Components.AdminTrainingTile;
 [ViewComponent(Name = "AdminTrainingTile")]
 public class AdminTrainingCardViewComponent : ViewComponent
 {
-    public IViewComponentResult Invoke(IGrouping<int, TrainingDto> model)
+    public IViewComponentResult Invoke(TrainingDto model)
     {
         return View(model ?? throw new ArgumentNullException(nameof(model)));
     }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/Default.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/Default.cshtml
@@ -1,25 +1,23 @@
 ﻿@using Microsoft.Extensions.Localization
-@using Smart.FA.Catalog.Core.Domain.Enumerations
-@using Smart.FA.Catalog.Core.SeedWork
 @using Smart.FA.Catalog.Shared.Domain.Enumerations
 @using Smart.FA.Catalog.Shared.Domain.Enumerations.Training
 
 @inject IStringLocalizer<CatalogResources> _localizer
-@model IGrouping<int, Core.Domain.Dto.TrainingDto>
+@model Core.Domain.Dto.TrainingDto
 
 <smart-card>
     <smart-card-body>
-        <smart-card-title text="@Model!.First().Title"></smart-card-title>
-        <smart-muted-text text="@string.Join(", ", @Model!.Where(training => training.TopicId != 0).Select(training => _localizer[Enumeration.FromValue<TrainingTopic>(training.TopicId).Name]))"></smart-muted-text>
+        <smart-card-title text="@Model.Title"></smart-card-title>
+        <smart-muted-text text="@string.Join(", ", Model.TopicIds!.Select(topic => _localizer[Enumeration.FromValue<TrainingTopic>(topic).Name])) "></smart-muted-text>
     </smart-card-body>
     <smart-card-actions>
         <div class="o-flex o-flex--vertical-center o-flex--justify-between o-flex--spaced-wide">
-            <smart-pill label="@(_localizer[Enumeration.FromValue<TrainingStatus>(Model!.First().StatusId).Name])"></smart-pill>
+            <smart-pill label="@(_localizer[Enumeration.FromValue<TrainingStatus>(Model!.StatusId).Name])"></smart-pill>
             <div class="c-button-toolbar">
-                <a href="/admin/trainings/update/@Model!.Key">
+                <a href="/admin/trainings/update/@Model!.TrainingId">
                     <smart-button leading-icon="EditAlt" button-style="Borderless"></smart-button>
                 </a>
-                <form method="post" asp-page-handler="Delete" asp-route-id="@Model!.Key">
+                <form method="post" asp-page-handler="Delete" asp-route-id="@Model!.TrainingId">
                     <smart-button icon-only="true" leading-icon="Delete" button-style="Borderless" button-type="Submit"></smart-button>
                 </form>
             </div>


### PR DESCRIPTION
The Introduction of topic ids (also called categories or tags) had broken the paging system of the list of trainings.
The PR maps topic ids to a list in Training dto with the multi-mapping feature of dapper to fix the paging.