### PR TITLE
Fix JS error on loading of most pages

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
@@ -1,7 +1,13 @@
 $(document).ready(
+    // This is used only by the creation and edition page therefore it could be move somewhere else.
+    // If one has the heart to do so he/she is welcome :).
+    // Btw try avoiding jQuery please :(.
     function(event)
     {
         let validateButton = document.getElementById("Save");
+        if (!validateButton) {
+           // return;
+        }
         validateButton.addEventListener("click", function(e)
         {
             let model = document.getElementById("isDraft");

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
@@ -1,5 +1,5 @@
 $(document).ready(
-    // This is used only by the creation and edition page therefore it could be move somewhere else.
+    // This is used only by the creation and edition page therefore it could be moved somewhere else.
     // If one has the heart to do so he/she is welcome :).
     // Btw try avoiding jQuery please :(.
     function(event)

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
@@ -6,7 +6,7 @@ $(document).ready(
     {
         let validateButton = document.getElementById("Save");
         if (!validateButton) {
-           // return;
+           return;
         }
         validateButton.addEventListener("click", function(e)
         {


### PR DESCRIPTION
There was  a onload event logic applied globally to every pages but that logic is related only to creation and edition pages.
Therefore opening any pages but those two would result in this:
'Cannot read properties of null (reading 'addEventListener')'.
This PR provides a quick and dirty fix by returning in nothing is found.

Internal ticket:
https://smartjira.atlassian.net/browse/CFA-322