### PR TITLE
Fix resolving S3 settings on development builds

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Development.json
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Development.json
@@ -19,20 +19,20 @@
   "AdminOptions": {
     "Training": {
       "NumberOfTrainingsDisplayed": 3
+    }
+  },
+  "S3Storage": {
+    "ImageBucketName": "cfa",
+    "FileSizeLimit": 2097152,
+    "DefaultTrainerProfilePictureName": "default_trainer_image",
+    "Credentials": {
+      "SecretKey": "newuser123",
+      "AccessKey": "newuser"
     },
-    "S3Storage": {
-      "ImageBucketName": "cfa",
-      "FileSizeLimit": 2097152,
-      "DefaultTrainerProfilePictureName" : "default_trainer_image",
-      "Credentials": {
-        "SecretKey": "newuser123",
-        "AccessKey": "newuser"
-      },
-      "AWS": {
-        "RegionEndpoint": "us-east-1",
-        "ServiceUrl": "http://localhost:9000",
-        "ForcePathStyle": true
-      }
+    "AWS": {
+      "RegionEndpoint": "us-east-1",
+      "ServiceUrl": "http://localhost:9000",
+      "ForcePathStyle": true
     }
   },
   "MediatR": {


### PR DESCRIPTION
S3Storage and AWS sections are nested into AdminOptions instead of being at the root.
This commit fixes that.