### PR TITLE
NuGet: update Smart.Design.Razor to its latest revision

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Smart.FA.Catalog.Web.csproj
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Smart.FA.Catalog.Web.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="NLog.Targets.ElasticSearch" Version="7.7.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
-    <PackageReference Include="Smart.Design.Razor" Version="1.0.17-beta" />
+    <PackageReference Include="Smart.Design.Razor" Version="1.0.19-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating to 1.0.19-alpha fixes main.css.map not being found.