### PR TITLE
Fix 404 http calls due to wrong <link> reference in HTML head tag

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -20,7 +20,6 @@
     <title>@ViewData["Title"]</title>
     <link rel="stylesheet" href="~/_content/Smart.Design.Razor/css/main.css"/>
     <link rel="stylesheet" href="~/Smart.FA.Catalog.Web.styles.css" />
-    <link rel="stylesheet" href="@(nameof(Smart.FA.Catalog.Web)).styles.css" />
 
 </head>
 <body class="u-maximize-height u-overflow-hidden">


### PR DESCRIPTION
<link rel="stylesheet" href="@(nameof(Smart.FA.Catalog.Web)).styles.css" /> is wrong synthax therefore
the  proxy middleware is being flooded due to the 404 response that redirects to the no found page.