### PR TITLE
Remove forced Preproduction appsettings

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Program.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Program.cs
@@ -13,7 +13,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 // appsettings.Local.json will have precedence over anything else as it is set in last.
 // https://github.com/dotnet/aspnetcore/blob/c5207d21ed68041879e1256406b458d130b420ab/src/DefaultBuilder/src/WebHost.cs#L170
-builder.Configuration.AddJsonFile("appsettings.PreProduction.json", optional: true, reloadOnChange: true);
 builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
 
 builder.Host.UseNLog();


### PR DESCRIPTION
A hotfix to remove forced Preproduction appsettings (useless, by default the app will take the appsettings based on the ASPNETCORE_ENVIRONMENT)