### PR TITLE
Disable event on key enter pressed on form in training creation and edition pages

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
@@ -104,3 +104,10 @@
         </div>
     </form>
 </smart-container>
+
+@section Scripts
+{
+    <script>
+        disableEnterKeyUpKeyPressOnForm();
+    </script>
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
@@ -108,3 +108,10 @@
 </smart-container>
 
 <div class="u-spacer"></div>
+
+@section Scripts
+{
+    <script>
+        disableEnterKeyUpKeyPressOnForm();
+    </script>
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/wwwroot/js/lib.js
@@ -61,3 +61,27 @@ function RegisterCultureChange() {
             ChangeCulture(event.target.value);
         });
 }
+
+function disableEnterKeyUpKeyPressOnForm() {
+    var forms = document.getElementsByTagName('form');
+    for (var i = 0; i < forms.length; i++) {
+        forms[i].addEventListener('keydown', ignoreEnterKeyEventHandler, true);
+        forms[i].addEventListener('keyup', ignoreEnterKeyEventHandler, true);
+    }
+
+    function disableEnterKeyEvent(e) {
+        if (e.keyIdentifier === 'U+000A' || e.keyIdentifier === 'Enter' || e.keyCode === 13) {
+            e.preventDefault();
+            return false;
+        }
+        return true;
+    }
+}
+
+function ignoreEnterKeyEventHandler(e) {
+    if (e.keyIdentifier === 'U+000A' || e.keyIdentifier === 'Enter' || e.keyCode === 13) {
+        e.preventDefault();
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
Just disable submitting the form when pressing enter on the create and edit page of trainings.
Hitting ENTER submit as a draft but we don't want necessarily to have that behavior.