### PR TITLE
ProfileViewModels: socialNetwork mapping: don't encapsulate parsing in a try-catch but check if name exists

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/ViewModels/Trainers/ProfileViewModels.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/ViewModels/Trainers/ProfileViewModels.cs
@@ -69,13 +69,10 @@ public static class Mappers
     public static Image ToImage(this SocialNetwork socialNetwork)
     {
         var icon = Image.None;
-        try
+        var existingImages = Enum.GetNames<Image>();
+        if (existingImages.Any(image => image.Equals(socialNetwork.Name, StringComparison.OrdinalIgnoreCase)))
         {
             icon = Enum.Parse<Image>(socialNetwork.Name, ignoreCase: true);
-        }
-        catch
-        {
-            // ignored
         }
 
         return icon;


### PR DESCRIPTION
GitHub social network doesn't exist nor the personal website in our icons.
Therefore there was a try catch surrounding the image enum parsing in case of failure.
Doing so raises error in debug mode on breaking on exception throwned.
this behavior is a bit annoying so this commit prevent exception being thrown.