### PR TITLE
Prefix path for nginx redirection

### DIFF
--- a/src/Showcase/src/Smart.FA.Catalog.Showcase.Web/Pages/Training/TrainingDetails/TrainingDetails.cshtml.cs
+++ b/src/Showcase/src/Smart.FA.Catalog.Showcase.Web/Pages/Training/TrainingDetails/TrainingDetails.cshtml.cs
@@ -23,7 +23,7 @@ public class TrainingDetailsModel : PageModel
         {
             //TO DO: add translated custom messages
             TempData["errorMessage"] = "There is no record for this request. Please try again.";
-            return RedirectToPage("/404");
+            return Redirect("/cfa/404");
         }
 
         var trainingDetails = await _context.TrainingDetails.Where(training => training.Id == id).ToListAsync();
@@ -32,7 +32,7 @@ public class TrainingDetailsModel : PageModel
         {
             //TO DO: add translated custom messages
             TempData["errorMessage"] = "This training does not exist! Please try again.";
-            return RedirectToPage("/404");
+            return Redirect("/cfa/404");
         }
 
         Training = MapTrainingDetails(trainingDetails);

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Authorization/Handlers/UserAdminAuthorizationResultHandler.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Authorization/Handlers/UserAdminAuthorizationResultHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Authorization.Policy;
@@ -27,13 +27,13 @@ public class UserAdminAuthorizationResultHandler : IAuthorizationMiddlewareResul
             // In the case of a failed requirement to have approved at least one valid user chart, the user will be redirected to the user chart approval page
             if (authorizationFailure.FailedRequirements.AnyOfType<AtLeastOneActiveUserChartRevisionApprovalRequirement>())
             {
-                context.Response.Redirect("/UserChart");
+                context.Response.Redirect("/cfa/userChart");
             }
 
             if (authorizationFailure.FailedRequirements.Any(failedRequirement =>
                     failedRequirement is RolesAuthorizationRequirement rolesAuthorizationRequirement && rolesAuthorizationRequirement.AllowedRoles.Contains("SuperUser")))
             {
-                context.Response.Redirect("/Admin");
+                context.Response.Redirect("/cfa/admin");
             }
 
             return;

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/404.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/404.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/cfa/404"
 
 <div class="c-error-page">
     <span class="c-error-page__code">404</span>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/cfa/admin"
 @model Smart.FA.Catalog.Web.Pages.Admin.IndexModel
 @{
     Layout = "Shared/_AdminLayout";

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/SideMenuItems.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/SideMenuItems.cs
@@ -6,8 +6,8 @@ public class SideMenuItem : Enumeration<SideMenuItem>
 {
     public string Href { get; }
 
-    public static readonly SideMenuItem MyProfile   = new(CatalogResources.MyTrainerProfile, 1, "/admin/myprofile");
-    public static readonly SideMenuItem MyTrainings = new(CatalogResources.MyTrainings, 2, "/admin/trainings/List");
+    public static readonly SideMenuItem MyProfile   = new(CatalogResources.MyTrainerProfile, 1, "/cfa/admin/trainers/myprofile");
+    public static readonly SideMenuItem MyTrainings = new(CatalogResources.MyTrainings, 2, "/cfa/admin/trainings/List");
 
     private SideMenuItem(string name, int value, string href) : base(value, name)
     {

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/admin/myprofile"
+﻿@page "/cfa/admin/trainers/myprofile"
 @using Microsoft.Extensions.Localization
 @using Smart.FA.Catalog.Web.Extensions
 @inject IStringLocalizer<CatalogResources> _stringLocalizer

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainers/Profile.cshtml.cs
@@ -36,7 +36,7 @@ public class ProfileModel : AdminPage
         // Trainer was not found.
         if (EditProfileCommand is null)
         {
-            return RedirectToPage("/404");
+            return Redirect("/cfa/404");
         }
 
         return Page();

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/cfa/admin/trainings/create"
 @using Microsoft.Extensions.Localization
 @using Smart.FA.Catalog.Shared.Domain.Enumerations.Common
 @using Smart.FA.Catalog.Shared.Domain.Enumerations.Training
@@ -17,7 +17,7 @@
             @if (Request.Query.ContainsKey("fromlist"))
             {
                 <div class="c-toolbar__item">
-                    <a class="c-button c-button--icon c-button--borderless" href="/admin/trainings/list/index">
+                    <a class="c-button c-button--icon c-button--borderless" href="/cfa/admin/trainings/list/index">
                         <div class="c-button__content">
                             <smart-icon icon="ArrowLeft"></smart-icon>
                             <div class="u-sr-accessible">@CatalogResources.Back</div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
@@ -40,7 +40,7 @@ public class CreateModel : AdminPage
 
         var request = CreateTrainingViewModel.MapToRequest(UserIdentity.CurrentTrainer.Id, UserIdentity.CurrentTrainer.DefaultLanguage);
         var response = await Mediator.Send(request);
-        return RedirectToPage("/Admin/Trainings/List/Index");
+        return Redirect("/cfa/admin/trainings/list");
     }
 
     protected override SideMenuItem GetSideMenuItem()

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/cfa/admin/trainings/list"
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<CatalogResources> _localizer
 @model Smart.FA.Catalog.Web.Pages.Admin.Trainings.List.ListModel
@@ -18,7 +18,7 @@
 
         <div class="c-toolbar__right">
             <smart-button-toolbar>
-                <a href="/admin/trainings/create?fromlist=">
+                <a href="/cfa/admin/trainings/create?fromlist=">
                     <smart-button label="@CatalogResources.AddNewTraining" leading-icon="Add"></smart-button>
                 </a>
             </smart-button-toolbar>
@@ -31,7 +31,7 @@
     <div class="c-error-page" style="height: 50%">
         <h4 class="c-error-page__title" style="font-size: 3.0rem;">@CatalogResources.YouDontHaveAnyTrainings</h4>
         <p class="c-error-page__desc" style="font-size: 2.4rem;">@CatalogResources.ClickHereToAddANewTraining</p>
-        <a class="c-button c-button--secondary" href="/admin/Trainings/Create">
+        <a class="c-button c-button--secondary" href="/cfa/admin/trainings/create">
             <span class="c-button__content">
                 <SmartIcon Icon="Icon.Add"></SmartIcon>
                 <span class="c-button__label">@CatalogResources.AddNewTraining</span>
@@ -100,9 +100,9 @@ else
         </div>
     </div>
 
-    @section Scripts
-    {
-        <script>
+@section Scripts
+{
+    <script>
                 // Submits the form surrounding the delete button of a training.
                 function deleteTraining(elem) {
                     document.getElementById('delete-training-form-' + elem.dataset.trainingid).submit();
@@ -113,5 +113,5 @@ else
                     document.getElementById('delete-training-button').dataset.trainingid = trainingId;
                 }
             </script>
-    }
+}
 }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{id:int}"
+﻿@page "/cfa/admin/trainings/update/{id:int}"
 @using Microsoft.Extensions.Localization
 @using Smart.FA.Catalog.Shared.Domain.Enumerations.Common
 @using Smart.FA.Catalog.Shared.Domain.Enumerations.Training
@@ -21,7 +21,7 @@
                     @if (Request.Query.ContainsKey("fromlist"))
                     {
                         <div class="c-toolbar__item">
-                            <a class="c-button c-button--icon c-button--borderless" href="/Admin/Trainings/List/Index">
+                            <a class="c-button c-button--icon c-button--borderless" href="/cfa/admin/trainings/list">
                                 <div class="c-button__content">
                                     <smart-icon icon="ArrowLeft"></smart-icon>
                                     <div class="u-sr-accessible">@CatalogResources.Back</div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml.cs
@@ -76,7 +76,7 @@ public class UpdateModel : AdminPage
         }
 
         // By Default we return to the user's training list.
-        return RedirectToPage("/Admin/Trainings/List/Index");
+        return Redirect("/cfa/admin/trainings/list");
     }
 
     protected override SideMenuItem GetSideMenuItem()

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Error.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Error.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "cfa/error"
 @model ErrorModel
 @{
     ViewData["Title"] = "Error";

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Index.cshtml
@@ -10,7 +10,7 @@
     <span class="c-error-page__code"></span>
     <h4 class="c-error-page__title title-size">Bienvenue</h4>
     <p class="c-error-page__desc message-size" style="font-size: 3.5rem;">Cliquez ici pour rejoindre votre espace membre</p>
-    <a class="c-button c-button--secondary" href="/admin/index">
+    <a class="c-button c-button--secondary" href="/cfa/admin">
         <span class="c-button__content">
             <span class="c-button__label ">Mon espace</span>
         </span>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/cfa"
 @model IndexModel
 @{
     Layout = "Shared/_Layout";

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/Default.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/Components/AdminTrainingTile/Default.cshtml
@@ -18,7 +18,7 @@
         <div class="o-flex o-flex--vertical-center o-flex--justify-between o-flex--spaced-wide">
             <smart-pill label="@(_localizer[TrainingStatusType.FromValue(training.StatusType).Name])"></smart-pill>
             <div class="c-button-toolbar">
-                <a href="/admin/trainings/update/@training!.Id">
+                <a href="/cfa/admin/trainings/update/@training!.Id">
                     <smart-button leading-icon="EditAlt" button-style="Borderless"></smart-button>
                 </a>
                 @if (Model.ShowDeleteButton)

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -33,7 +33,7 @@
                 <div class="c-toolbar__left">
                     <div class="c-toolbar__item">
                         <div class="c-brand c-brand--xsmall">
-                            <a href="/">
+                            <a href="/smart.aspx">
                                 <img src="https://design.smart.coop/images/logo.svg" alt="Smart">
                             </a>
                         </div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -63,7 +63,7 @@
                             </li>
                             <li class="c-menu__divider" role="presentational"></li>
                             <li class="c-menu__item">
-                                <a class="c-menu__label" href="#">@CatalogResources.SignOut</a>
+                                <a class="c-menu__label" href="/logout.aspx">@CatalogResources.SignOut</a>
                             </li>
                         </ul>
                     </div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -53,13 +53,13 @@
                     <div class="c-toolbar__item">
                         <a class="c-user-navigation" href="#" data-menu="userMenu">
                             <div class="c-avatar c-avatar--img">
-                                <img src="/admin/myprofile?handler=LoadImage" alt="avatar">
+                                <img src="/cfa/admin/trainers/myprofile?handler=LoadImage" alt="avatar">
 
                             </div>
                         </a>
                         <ul class="c-menu c-menu--large" id="userMenu">
                             <li class="c-menu__item">
-                                <a class="c-menu__label" href="/admin">@CatalogResources.MyUserSpace</a>
+                                <a class="c-menu__label" href="/cfa/admin">@CatalogResources.MyUserSpace</a>
                             </li>
                             <li class="c-menu__divider" role="presentational"></li>
                             <li class="c-menu__item">

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
@@ -47,7 +47,7 @@
                     <div class="c-toolbar__item">
                         <a class="c-user-navigation" href="#" data-menu="userMenu">
                             <div class="c-avatar c-avatar--img">
-                                <img src="/admin/myprofile?handler=LoadImage" alt="avatar">
+                                <img src="/cfa/admin/myprofile?handler=LoadImage" alt="avatar">
                             </div>
                         </a>
                         <ul class="c-menu c-menu--large" id="userMenu">

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
                 <div class="c-toolbar__left">
                     <div class="c-toolbar__item">
                         <div class="c-brand c-brand--xsmall">
-                            <a href="/">
+                            <a href="/smart.aspx">
                                 <img src="https://design.smart.coop/images/logo.svg" alt="Smart">
                             </a>
                         </div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/SuperUser/Trainings/List/SuperUserTrainingList.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/SuperUser/Trainings/List/SuperUserTrainingList.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/superuser/trainings"
+﻿@page "/cfa/superuser/trainings"
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Microsoft.Extensions.Localization
 @using Smart.Design.Razor.TagHelpers.Alert

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/userchart"
+﻿@page "/cfa/userchart"
 @model UserChartModel
 @{
     Layout = "Shared/_Layout";

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
@@ -35,7 +35,7 @@ public class UserChartModel : PageModel
         }
 
         await Mediator.Send(new SetTrainerHasAcceptedLatestUserChartRequest { TrainerId = UserIdentity.Id });
-        return RedirectToPage("/Admin/Index");
+        return Redirect("/cfa/admin");
     }
 
     public async Task<string> GetLastChartUrl()


### PR DESCRIPTION
This PR introduces necessary changes for a proper Nginx redirection.
Notably to add systematically a keyword (here cfa) that can be picked up by both Account and CFA.

- It's not ideal but the keyword "cfa" was preprended manually to all pages.
- It also redirects to account aspx page on the home logo and the logout. Note there are no fallback routes as of now, either.