### PR TITLE
CreateTrainingRequestValidator: add missing translation for training title validation

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Validators/CreateTrainingRequestValidator.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Validators/CreateTrainingRequestValidator.cs
@@ -16,8 +16,10 @@ public class CreateTrainingRequestValidator : AbstractValidator<CreateTrainingVi
     public CreateTrainingRequestValidator(IStringLocalizer<CatalogResources> localizer, IUserIdentity userIdentity)
     {
         _userIdentity = userIdentity;
+
         RuleFor(viewModel => viewModel.Title)
             .NotEmpty()
+            .WithMessage(CatalogResources.TrainingTitleIsRequired)
             .MaximumLength(500)
             .WithMessage(CatalogResources.TrainingTitleIsRequired);
 


### PR DESCRIPTION
Translation was missing when the training field is empty.