### PR TITLE
Prevent invalid operation when approving an already approved user chart revision

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Trainer/Trainer.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Core/Domain/Trainer/Trainer.cs
@@ -145,11 +145,11 @@ public class Trainer : Entity, IAggregateRoot
     public void ApproveUserChart(UserChartRevision? userChart)
     {
         Guard.AgainstNull(userChart, nameof(userChart));
-        if (_approvals.Select(approval => approval.UserChartId).Contains(userChart!.Id))
+        if (Approvals.Any(approval => approval.UserChartId == userChart!.Id))
         {
             return;
         }
-        _approvals.Add(new TrainerApproval(this, userChart));
+        _approvals.Add(new TrainerApproval(this, userChart!));
     }
 
     #endregion

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml
@@ -6,13 +6,13 @@
 
 <form method="post" id="form" class="o-container u-spacer-top-xl">
     <smart-panel header="@CatalogResources.AdminHomepage_AcceptCharter">
-        <a href="@Model.GetLastChartUrl().Result" target="_blank">@CatalogResources.AdminHomePage_UserChart</a>
+        <a href="@Model.LastChartUrl" target="_blank">@CatalogResources.AdminHomePage_UserChart</a>
         <smart-spacer top="Large">
             <smart-checkbox label="@CatalogResources.AdminHomepage_AcceptCharter" asp-for="@Model.HasAcceptedUserChart"></smart-checkbox>
             <smart-validation-message asp-for="@Model"></smart-validation-message>
         </smart-spacer>
         <smart-spacer top="Large">
-            <smart-button id="Accept" label="@CatalogResources.UserChartAccept" button-style="Primary" leading-icon="Send" button-type="Submit" disabled=@(HttpContext.Request.Cookies.TryGetValue("HasAcceptedUserChart", out _))> </smart-button>
+            <smart-button id="Accept" label="@CatalogResources.UserChartAccept" button-style="Primary" leading-icon="Send" button-type="Submit"> </smart-button>
         </smart-spacer>
     </smart-panel>
 </form>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
@@ -52,16 +52,10 @@ public class UserChartModel : PageModel
         return RedirectToPage("/Admin/Index");
     }
 
-    private async Task<bool> ShouldReturnToHomePageAsync()
-    {
-        // There is no point to go any further if the user is either a Super User or if he has accepted already an active chart.
-        if (_userIdentity.IsSuperUser || await _mediator.Send(new HasAcceptedOneActiveUserChartRevisionQuery(_userIdentity.Id)))
-        {
-            return true;
-        }
-
-        return false;
-    }
+    // There is no point to go any further if the user is either a Super User or if he has accepted already an active chart.
+    private async Task<bool> ShouldReturnToHomePageAsync() => _userIdentity.IsSuperUser || await _mediator.Send(new HasAcceptedOneActiveUserChartRevisionQuery(_userIdentity.Id));
+    
+    
 
     public async Task<string> GetLastChartUrlAsync()
     {

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/UserChart.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Smart.FA.Catalog.Application.UseCases.Commands;
@@ -9,38 +9,63 @@ namespace Smart.FA.Catalog.Web.Pages;
 
 public class UserChartModel : PageModel
 {
-    private IMediator Mediator { get; }
+    private readonly IMediator _mediator;
 
-    public IUserIdentity UserIdentity { get; }
+    private readonly IUserIdentity _userIdentity;
 
-    [BindProperty] public bool HasAcceptedUserChart { get; set; } = false;
+    [BindProperty]
+    public bool HasAcceptedUserChart { get; set; } = false;
 
-    public ActionResult OnGet()
-    {
-        return Page();
-    }
+    public string LastChartUrl { get; private set; } = null!;
 
     public UserChartModel(IMediator mediator, IUserIdentity userIdentity)
     {
-        Mediator = mediator;
-        UserIdentity = userIdentity;
+        _mediator = mediator;
+        _userIdentity = userIdentity;
+    }
+
+    public async Task<ActionResult> OnGetAsync()
+    {
+        if (await ShouldReturnToHomePageAsync())
+        {
+            return RedirectToPage("/Admin/Index");
+        }
+
+        LastChartUrl = await GetLastChartUrlAsync();
+        return Page();
     }
 
     public async Task<ActionResult> OnPostAsync()
     {
-        if (HasAcceptedUserChart is false)
+        if (await ShouldReturnToHomePageAsync())
+        {
+            return RedirectToPage("/Admin/Index");
+        }
+
+        if (!HasAcceptedUserChart)
         {
             ModelState.AddModelError(string.Empty, CatalogResources.AdminHomePage_HasNotAcceptedUserChart);
             return Page();
         }
 
-        await Mediator.Send(new SetTrainerHasAcceptedLatestUserChartRequest { TrainerId = UserIdentity.Id });
+        await _mediator.Send(new SetTrainerHasAcceptedLatestUserChartRequest { TrainerId = _userIdentity.Id });
         return RedirectToPage("/Admin/Index");
     }
 
-    public async Task<string> GetLastChartUrl()
+    private async Task<bool> ShouldReturnToHomePageAsync()
     {
-        var response = await Mediator.Send(new GetLatestUserChartRevisionUrlRequest());
+        // There is no point to go any further if the user is either a Super User or if he has accepted already an active chart.
+        if (_userIdentity.IsSuperUser || await _mediator.Send(new HasAcceptedOneActiveUserChartRevisionQuery(_userIdentity.Id)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public async Task<string> GetLastChartUrlAsync()
+    {
+        var response = await _mediator.Send(new GetLatestUserChartRevisionUrlRequest());
 
         // If we ever find ourselves in a case where no user chart can't be retrieved from storage, we should display the base user chart in wwwroot (to avoid any legal conflict)
         // However it also means it should be updated regularly


### PR DESCRIPTION
Approving an already approved user chart revision leads to a duplication of primary key of the many to many table between userchart revisions and trainers.
Fixed that behavior by loading correctly the current trainer's user chart approvals and also redirect to the home page users that are either super user or having approved a active user chart revision.