### PR TITLE
LoggingPipelineBehavior: don't log Trainer nor Training domain models that transit through MediatR

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/Interceptors/LoggingPipelineBehavior.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/Interceptors/LoggingPipelineBehavior.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Smart.FA.Catalog.Application.Models.Options;
 using Smart.FA.Catalog.Application.SeedWork;
+using Smart.FA.Catalog.Application.SeedWork.Json.Converters;
 using Smart.FA.Catalog.Core.Exceptions;
 using Smart.FA.Catalog.Core.Extensions;
 using Smart.FA.Catalog.Core.LogEvents;
@@ -65,8 +66,16 @@ public class LoggingPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TR
         // Ses https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-preserve-references?pivots=dotnet-6-0.
         var jsonSerializerOptions = new JsonSerializerOptions()
         {
-            WriteIndented = true,
-            ReferenceHandler = ReferenceHandler.Preserve
+            WriteIndented    = true,
+            ReferenceHandler = ReferenceHandler.Preserve,
+            Converters =
+            {
+                new TrainerJsonConverter(),
+                new TrainingJsonConverter(),
+                new UserChartRevisionJsonConverter(),
+                new SuperUserJsonConverter(),
+                new TrainerAssignmentJsonConverter()
+            }
         };
 
         return request.ToJson(jsonSerializerOptions);

--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/SuperUserJsonConverter.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/SuperUserJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Smart.FA.Catalog.Core.Domain.Authorization;
+
+namespace Smart.FA.Catalog.Application.SeedWork.Json.Converters;
+
+public class SuperUserJsonConverter : JsonConverter<SuperUser>
+{
+    public override SuperUser? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as SuperUser;
+    }
+
+    public override void Write(Utf8JsonWriter writer, SuperUser superUser, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(superUser.UserId);
+    }
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainerAssignmentJsonConverter.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainerAssignmentJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Smart.FA.Catalog.Core.Domain;
+
+namespace Smart.FA.Catalog.Application.SeedWork.Json.Converters;
+
+public class TrainerAssignmentJsonConverter : JsonConverter<TrainerAssignment>
+{
+    public override TrainerAssignment? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as TrainerAssignment;
+    }
+
+    public override void Write(Utf8JsonWriter writer, TrainerAssignment trainerAssignment, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue($"[TrainerId: {trainerAssignment.TrainerId}, TrainingId: {trainerAssignment.TrainingId}]");
+    }
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainerJsonConverter.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainerJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Smart.FA.Catalog.Core.Domain;
+
+namespace Smart.FA.Catalog.Application.SeedWork.Json.Converters;
+
+public class TrainerJsonConverter : JsonConverter<Trainer>
+{
+    public override Trainer? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as Trainer;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Trainer trainer, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(trainer.Id);
+    }
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainingJsonConverter.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/TrainingJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Smart.FA.Catalog.Core.Domain;
+
+namespace Smart.FA.Catalog.Application.SeedWork.Json.Converters;
+
+public class TrainingJsonConverter : JsonConverter<Training>
+{
+    public override Training? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as Training;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Training value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value.Id);
+    }
+}

--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/UserChartRevisionJsonConverter.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/SeedWork/Json/Converters/UserChartRevisionJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Smart.FA.Catalog.Core.Domain;
+
+namespace Smart.FA.Catalog.Application.SeedWork.Json.Converters;
+
+public class UserChartRevisionJsonConverter : JsonConverter<UserChartRevision>
+{
+    public override UserChartRevision? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, options) as UserChartRevision;
+    }
+
+    public override void Write(Utf8JsonWriter writer, UserChartRevision userChartRevision, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(userChartRevision.Id);
+    }
+}


### PR DESCRIPTION
Due to circular references between properties of entities like Trainer and Training (they are aggregate/entities after all) serialization 
 produces very large JSON because of the lazy loading enable in EF Core.

Serializing an object make the serializer accessing every public properties; this trigger lazy evaluation of each unloaded ones which can result in unnecessary and heavy SQL statements.

Commit 9188b484c36031536ac373fbd0691b381962e23a serializes request that results in an exception, I was to avoid the issues described above.

This commit adds five JsonConverters on entities that are sent between web and BL to convert them to their primary key value rather the whole object value.

This should be considered as a dirty fix and DTOs should be considered over entities; or domain models that are not entities under the hood.