### PR TITLE
Update HTML of usermenu to match account

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_AdminLayout.cshtml
@@ -61,6 +61,21 @@
                             </div>
                         </a>
                         <ul class="c-menu c-menu--large" id="userMenu">
+                            <li class="c-menu__info">
+                                <div class="c-avatar-and-text">
+                                    <div class="c-avatar c-avatar--img">
+                                        <img src="@(MinIoLinkGenerator.GetAbsoluteTrainerProfilePictureUrl(UserIdentity.CurrentTrainer.ProfileImagePath))" alt="avatar">
+                                    </div>
+                                    <div class="c-avatar-and-text__text">
+                                        <p>
+                                            <strong>
+                                                @UserIdentity.Identity.Name
+                                            </strong>
+                                        </p>
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="c-menu__divider" role="presentational"></li>
                             <li class="c-menu__item">
                                 <a class="c-menu__label" href="/cfa/admin">@CatalogResources.MyUserSpace</a>
                             </li>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Shared/_Layout.cshtml
@@ -58,8 +58,23 @@
                             </div>
                         </a>
                         <ul class="c-menu c-menu--large" id="userMenu">
+                            <li class="c-menu__info">
+                                <div class="c-avatar-and-text">
+                                    <div class="c-avatar c-avatar--img">
+                                        <img src="@(MinIoLinkGenerator.GetAbsoluteTrainerProfilePictureUrl(UserIdentity.CurrentTrainer.ProfileImagePath))" alt="avatar">
+                                    </div>
+                                    <div class="c-avatar-and-text__text">
+                                        <p>
+                                            <strong>
+                                                @UserIdentity.Identity.Name
+                                            </strong>
+                                        </p>
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="c-menu__divider" role="presentational"></li>
                             <li class="c-menu__item">
-                                <a class="c-menu__label" href="#">@CatalogResources.MyUserSpace</a>
+                                <a class="c-menu__label" href="/cfa/admin">@CatalogResources.MyUserSpace</a>
                             </li>
                             <li class="c-menu__divider" role="presentational"></li>
                             <li class="c-menu__item">


### PR DESCRIPTION
HTML was ajusted from https://design.smart.coop/prototypes/account/user-homepage-with-menu.html.

![image](https://user-images.githubusercontent.com/90202188/168593038-606802f2-2509-4307-a551-0739ae414779.png)
