### PR TITLE
Surround global banner on training listing page with a o-container

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/List/Index.cshtml
@@ -28,9 +28,11 @@
 
 @if (TempData.HasGlobalBannerMessage())
 {
-    <smart-spacer left="ExtraLarge" right="ExtraLarge" top="Small">
-        <smart-alert style="@TempData.GetGlobalBannerMessage().Style" message="@TempData.GetGlobalBannerMessage().Message" is-closable="true"></smart-alert>
-    </smart-spacer>
+    <div class="o-container">
+        <smart-spacer left="ExtraLarge" right="ExtraLarge" top="Small">
+            <smart-alert style="@TempData.GetGlobalBannerMessage().Style" message="@TempData.GetGlobalBannerMessage().Message" is-closable="true"></smart-alert>
+        </smart-spacer>
+    </div>
 }
 
 @if (Model.Trainings is not null && !Model.Trainings.Any())


### PR DESCRIPTION
Due to the HTML update of the list page the changes need to be reflected on the global banner also.

![image](https://user-images.githubusercontent.com/90202188/168592551-8ffd5069-8d07-4460-b29b-18b65b7d95e8.png)

becomes 


![image](https://user-images.githubusercontent.com/90202188/168592506-76c8d589-168d-4d08-ae77-f327b0a75785.png)
