### PR TITLE
Make URL of Showcase website customizable accordingly to underlying environment

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Options/UrlOptions.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Options/UrlOptions.cs
@@ -7,4 +7,6 @@ public class UrlOptions
     public string Home { get; set; }
 
     public string SignOut {get; set;}
+
+    public string Showcase { get; set; }
 }

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Index.cshtml
@@ -1,4 +1,9 @@
 ﻿@page
+@using Microsoft.Extensions.Options
+@using Smart.FA.Catalog.Web.Options
+
+@inject IOptions<UrlOptions> UrlOptions
+
 @model Smart.FA.Catalog.Web.Pages.Admin.IndexModel
 @{
     Layout = "Shared/_AdminLayout";
@@ -17,9 +22,9 @@
 }
 <div class="o-container">
     <smart-panel header="@CatalogResources.AdminHomepage_WhatIsFormateurAssocieTitle">
-        <p class="intro__paragraph"><a href="https://@CatalogResources.UrlSitePublic">@CatalogResources.UrlSitePublic</a> @CatalogResources.AdminHomepage_IntroductionPart1</p>
+        <p class="intro__paragraph"><a href="@UrlOptions.Value.Showcase">@CatalogResources.UrlSitePublic</a> @CatalogResources.AdminHomepage_IntroductionPart1</p>
         <p class="intro__paragraph">@CatalogResources.AdminHomepage_IntroductionPart2</p>
-        <p class="intro__paragraph">@CatalogResources.AdminHomepage_IntroductionPart3 <a href="https://@CatalogResources.UrlSitePublic">@CatalogResources.UrlSitePublic</a>.</p>
+        <p class="intro__paragraph">@CatalogResources.AdminHomepage_IntroductionPart3 <a href="@UrlOptions.Value.Showcase">@CatalogResources.UrlSitePublic</a>.</p>
     </smart-panel>
 
     <smart-spacer bottom="ExtraLarge" top="ExtraLarge"></smart-spacer>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.PreProduction.json
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.PreProduction.json
@@ -39,7 +39,8 @@
   },
   "Url": {
     "Home": "https://account-stage.ubik.be/home",
-    "SignOut": "https://account-stage.ubik.be/logout"
+    "SignOut": "https://account-stage.ubik.be/logout",
+    "Showcase": "https://learning-stage.smartcoop.dev"
   },
   "Authentication": {
     "UseFakeHeaders": false

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Production.json
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.Production.json
@@ -39,7 +39,8 @@
   },
   "Url": {
     "Home": "https://account.ubik.be/cfa.aspx",
-    "SignOut": "https://account.ubik.be/logout.aspx"
+    "SignOut": "https://account.ubik.be/logout.aspx",
+    "Showcase": "https://learning.smart.coop"
   },
   "Authentication": {
     "UseFakeHeaders": false

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.json
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/appsettings.json
@@ -46,7 +46,8 @@
   },
   "Url": {
     "Home": "/cfa",
-    "SignOut": "/cfa"
+    "SignOut": "/cfa",
+    "Showcase": "https://localhost:7019"
   },
   "Authentication": {
     "UseFakeHeaders": false


### PR DESCRIPTION
The production URL of the Showcase website was hardcoded. It can now be set through an option.