### PR TITLE
Prepend https protocol on social network urls

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Application/UseCases/Commands/EditProfileCommand.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Application/UseCases/Commands/EditProfileCommand.cs
@@ -99,6 +99,13 @@ public class EditProfileCommandHandler : IRequestHandler<EditProfileCommand, Pro
         {
             var socialNetwork = SocialNetwork.FromValue(commandSocial.Key);
             var url = commandSocial.Value;
+            if (!string.IsNullOrEmpty(url) &&
+                !url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                url = "https://" + url;
+            }
+
             trainer.SetSocialNetwork(socialNetwork, url);
         }
     }


### PR DESCRIPTION
in order to make 
```html
<a> 
```
HTML tags work the uri must have a http or https protocol set in the url.

example: 

```html
<a href="www.smart.coop"  /> 
```
won't point to http://www.smart.coop 

This commit ensures that https protool is prepended when a trainer saves its profile.