### PR TITLE
Extract training creation/edition form into a partial view

### DIFF
--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/CreateTrainingViewModel.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/CreateTrainingViewModel.cs
@@ -1,9 +1,6 @@
-using System.Diagnostics.CodeAnalysis;
 using Smart.FA.Catalog.Application.UseCases.Commands;
 using Smart.FA.Catalog.Core.Domain.Dto;
 using Smart.FA.Catalog.Core.Domain.ValueObjects;
-using Smart.FA.Catalog.Shared.Domain.Enumerations;
-using Smart.FA.Catalog.Shared.Domain.Enumerations.Common;
 using Smart.FA.Catalog.Shared.Domain.Enumerations.Training;
 
 namespace Smart.FA.Catalog.Web.Pages.Admin.Trainings.Create;

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml
@@ -1,7 +1,5 @@
 ﻿@page
 @using Microsoft.Extensions.Localization
-@using Smart.FA.Catalog.Shared.Domain.Enumerations.Common
-@using Smart.FA.Catalog.Shared.Domain.Enumerations.Training
 @inject IStringLocalizer<CatalogResources> _localizer
 @model Smart.FA.Catalog.Web.Pages.Admin.Trainings.Create.CreateModel
 @{
@@ -43,121 +41,9 @@
 }
 
 <div class="o-container">
-    <form method="post" id="form" class="u-spacer-xl">
-        <div class="o-form-group-layout o-form-group-layout--standard">
-
-            <smart-panel header="@CatalogResources.FieldsThatWillAppearInThePublicCatalog">
-
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingTitleCreationLabel * <span data-tooltip="tooltip-title" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-input asp-for="CreateTrainingViewModel.Title"></smart-input>
-                        <smart-validation-message asp-for="CreateTrainingViewModel.Title"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                @if (Model.UserIdentity.IsSuperUser)
-                {
-                    <smart-checkbox label="@CatalogResources.IsTrainingGivenBySmart" asp-for="CreateTrainingViewModel.IsGivenBySmart"></smart-checkbox>
-                    <smart-validation-message asp-for="CreateTrainingViewModel.IsGivenBySmart"></smart-validation-message>
-                }
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingPresentation * <span data-tooltip="tooltip-presentation" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="CreateTrainingViewModel.Methodology" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="CreateTrainingViewModel.Methodology"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingGoal * <span data-tooltip="tooltip-objectif" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="CreateTrainingViewModel.Goal" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="CreateTrainingViewModel.Goal"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-                
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.PracticalModalities * <span data-tooltip="tooltip-modalities" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="CreateTrainingViewModel.PracticalModalities" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="CreateTrainingViewModel.PracticalModalities"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.Topics *">
-                    <smart-grid>
-                        @foreach (var topics in Topic.List.Chunk(2))
-                        {
-                            @foreach (var topic in topics)
-                            {
-                                <smart-grid-column width="4">
-                                    <smart-checkbox label="@_localizer[topic.Name]" asp-for="CreateTrainingViewModel.TopicIds" value="@topic.Id" checked="@(topic.IsContainedIn(Model.CreateTrainingViewModel.TopicIds))"></smart-checkbox>
-                                </smart-grid-column>
-                            }
-                        }
-                    </smart-grid>
-                    <smart-validation-message asp-for="CreateTrainingViewModel.TopicIds"></smart-validation-message>
-                </smart-formgroup>
-            </smart-panel>
-
-            <smart-spacer top="ExtraLarge" bottom="ExtraLarge"></smart-spacer>
-
-            <smart-panel header="@CatalogResources.TrainingVatJustification">
-                <smart-formgroup label="@CatalogResources.TheTraining *">
-                    @foreach (var vatExemptionType in VatExemptionType.List)
-                    {
-                        <smart-checkbox label="@_localizer["Training_Is" + vatExemptionType.Name]" asp-for="CreateTrainingViewModel.VatExemptionTypeIds" value="@vatExemptionType.Id" checked="@(vatExemptionType.IsContainedIn(Model.CreateTrainingViewModel.VatExemptionTypeIds))"></smart-checkbox>
-                    }
-                    <smart-validation-message asp-for="CreateTrainingViewModel.VatExemptionTypeIds"></smart-validation-message>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.TrainingTarget *">
-                    @foreach (var targetAudience in TargetAudienceType.List)
-                    {
-                        <smart-checkbox label="@_localizer[targetAudience.Name]" asp-for="CreateTrainingViewModel.TargetAudienceTypeIds" value="@targetAudience.Id" checked="@(targetAudience.IsContainedIn(Model.CreateTrainingViewModel.TargetAudienceTypeIds))"></smart-checkbox>
-                    }
-                    <smart-validation-message asp-for="CreateTrainingViewModel.TargetAudienceTypeIds"></smart-validation-message>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.Training_IsItATrainingThat *">
-                    @foreach (var attendanceType in AttendanceType.List)
-                    {
-                        <smart-checkbox asp-for="CreateTrainingViewModel.AttendanceTypeIds" value="@attendanceType.Id" label="@_localizer["Training_" + attendanceType.Name]" checked="@(attendanceType.IsContainedIn(Model.CreateTrainingViewModel.AttendanceTypeIds))"></smart-checkbox>
-                    }
-                </smart-formgroup>
-                <smart-validation-message asp-for="CreateTrainingViewModel.AttendanceTypeIds"></smart-validation-message>
-            </smart-panel>
-
-            <input type="hidden" id="isDraft" value="false" asp-for="CreateTrainingViewModel.IsDraft"/>
-
-        </div>
-    </form>
+  @await Html.PartialAsync("Admin/Trainings/Shared/_TrainingCreationEditionForm", Model.CreateTrainingViewModel)
 </div>
 
-<div>
-    <div class="c-tooltip" id="tooltip-title" role="tooltip">@CatalogResources.AddTrainingTooltip_Title
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-presentation" role="tooltip">@CatalogResources.AddTrainingTooltip_Presentation
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-objectif" role="tooltip">@CatalogResources.AddTrainingTooltip_Objectif
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-modalities" role="tooltip">@CatalogResources.AddTrainingTooltip_Modalities
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-</div>
 @section Scripts
 {
     <script>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Create/Index.cshtml.cs
@@ -10,18 +10,14 @@ namespace Smart.FA.Catalog.Web.Pages.Admin.Trainings.Create;
 
 public class CreateModel : AdminPage
 {
-    private readonly ILogger<CreateModel> _logger;
     private readonly UrlOptions _urlOptions;
 
     public IUserIdentity UserIdentity { get; }
 
     [BindProperty] public CreateTrainingViewModel CreateTrainingViewModel { get; set; } = new();
 
-    public string ShowcaseTrainingDetailsUrl { get; set; }
-
-    public CreateModel(IMediator mediator, ILogger<CreateModel> logger, IUserIdentity userIdentity, IOptions<UrlOptions> urlOptions) : base(mediator)
+    public CreateModel(IMediator mediator, IUserIdentity userIdentity, IOptions<UrlOptions> urlOptions) : base(mediator)
     {
-        _logger = logger;
         UserIdentity = userIdentity;
         _urlOptions = urlOptions.Value ?? throw new ArgumentException($"{urlOptions} not found");
     }
@@ -44,13 +40,13 @@ public class CreateModel : AdminPage
             return Page();
         }
 
-        var request = CreateTrainingViewModel.MapToRequest(UserIdentity.CurrentTrainer.Id, UserIdentity.CurrentTrainer.DefaultLanguage);
-        var reponse = await Mediator.Send(request);
+        var createTrainingRequest = CreateTrainingViewModel.MapToRequest(UserIdentity.CurrentTrainer.Id, UserIdentity.CurrentTrainer.DefaultLanguage);
+        var response = await Mediator.Send(createTrainingRequest);
 
         TempData.AddGlobalAlertMessage(CatalogResources.TrainingCreatedWithSuccess, AlertStyle.Success);
-        if (!request.IsDraft)
+        if (!createTrainingRequest.IsDraft)
         {
-            TempData["Url"] = _urlOptions.GetShowcaseTrainingDetailsUrl(reponse.TrainingId);
+            TempData["Url"] = _urlOptions.GetShowcaseTrainingDetailsUrl(response.TrainingId);
         }
 
         return RedirectToPage("/Admin/Trainings/List/Index");

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Shared/_TrainingCreationEditionForm.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Shared/_TrainingCreationEditionForm.cshtml
@@ -1,0 +1,149 @@
+﻿@using Microsoft.Extensions.Localization
+@using Smart.Design.Razor.TagHelpers.Elements.Checkbox
+@using Smart.Design.Razor.TagHelpers.Elements.Textarea
+@using Smart.Design.Razor.TagHelpers.FormGroup
+@using Smart.Design.Razor.TagHelpers.Grid
+@using Smart.Design.Razor.TagHelpers.Icon
+@using Smart.Design.Razor.TagHelpers.Panel
+@using Smart.Design.Razor.TagHelpers.Spacer
+@using Smart.FA.Catalog.Core.Services
+@using Smart.FA.Catalog.Shared.Domain.Enumerations.Common
+@using Smart.FA.Catalog.Shared.Domain.Enumerations.Training
+@model Smart.FA.Catalog.Web.Pages.Admin.Trainings.Create.CreateTrainingViewModel
+@inject IStringLocalizer<CatalogResources> Localizer
+@{
+    var identityService = ViewContext.HttpContext.RequestServices.GetRequiredService<IUserIdentity>();
+
+    var superUser = identityService.IsSuperUser;
+}
+
+<form method="post" id="form" class="u-spacer-xl">
+    <div class="o-form-group-layout o-form-group-layout--standard">
+        <smart-panel header="@CatalogResources.FieldsThatWillAppearInThePublicCatalog">
+
+            <smart-formgroup>
+                <label class="o-form-group__label">
+                    @CatalogResources.TrainingTitleCreationLabel *
+                    <span data-tooltip="tooltip-title" data-tooltip-placement="top" class="icon-help">
+                        <smart-icon icon="CircleHelp"></smart-icon>
+                    </span>
+                </label>
+                <smart-formgroup-controls>
+                    <smart-input asp-for="Title"></smart-input>
+                    <smart-validation-message asp-for="Title"></smart-validation-message>
+                </smart-formgroup-controls>
+            </smart-formgroup>
+
+            @if (superUser)
+            {
+                <smart-checkbox label="@CatalogResources.IsTrainingGivenBySmart" asp-for="IsGivenBySmart"></smart-checkbox>
+                <smart-validation-message asp-for="IsGivenBySmart"></smart-validation-message>
+            }
+            <smart-formgroup>
+                <label class="o-form-group__label">
+                    @CatalogResources.TrainingPresentation *
+                    <span data-tooltip="tooltip-presentation" data-tooltip-placement="top" class="icon-help">
+                        <smart-icon icon="CircleHelp"></smart-icon>
+                    </span>
+                </label>
+                <smart-formgroup-controls>
+                    <smart-textarea asp-for="Methodology" rows="5"></smart-textarea>
+
+                    <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
+                    <smart-validation-message asp-for="Methodology"></smart-validation-message>
+                </smart-formgroup-controls>
+            </smart-formgroup>
+
+            <smart-formgroup>
+                <label class="o-form-group__label">
+                    @CatalogResources.TrainingGoal *
+                    <span data-tooltip="tooltip-objectif" data-tooltip-placement="top" class="icon-help">
+                        <smart-icon icon="CircleHelp"></smart-icon>
+                    </span>
+                </label>
+                <smart-formgroup-controls>
+                    <smart-textarea asp-for="Goal" rows="5"></smart-textarea>
+
+                    <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
+                    <smart-validation-message asp-for="Goal"></smart-validation-message>
+                </smart-formgroup-controls>
+            </smart-formgroup>
+
+            <smart-formgroup>
+                <label class="o-form-group__label">
+                    @CatalogResources.PracticalModalities *
+                    <span data-tooltip="tooltip-modalities" data-tooltip-placement="top" class="icon-help">
+                        <smart-icon icon="CircleHelp"></smart-icon>
+                    </span>
+                </label>
+                <smart-formgroup-controls>
+                    <smart-textarea asp-for="PracticalModalities" rows="5"></smart-textarea>
+
+                    <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
+                    <smart-validation-message asp-for="PracticalModalities"></smart-validation-message>
+                </smart-formgroup-controls>
+            </smart-formgroup>
+
+            <smart-formgroup label="@CatalogResources.Topics *">
+                <smart-grid>
+                    @foreach (var topics in Topic.List.Chunk(2))
+                    {
+                        @foreach (var topic in topics)
+                        {
+                            <smart-grid-column width="4">
+                                <smart-checkbox label="@Localizer[topic.Name]" asp-for="TopicIds" value="@topic.Id" checked="@(topic.IsContainedIn(Model.TopicIds))"></smart-checkbox>
+                            </smart-grid-column>
+                        }
+                    }
+                </smart-grid>
+                <smart-validation-message asp-for="TopicIds"></smart-validation-message>
+            </smart-formgroup>
+        </smart-panel>
+
+        <smart-spacer top="ExtraLarge" bottom="ExtraLarge"></smart-spacer>
+
+        <smart-panel header="@CatalogResources.TrainingVatJustification">
+            <smart-formgroup label="@CatalogResources.TheTraining *">
+                @foreach (var vatExemptionType in VatExemptionType.List)
+                {
+                    <smart-checkbox label="@Localizer["Training_Is" + vatExemptionType.Name]" asp-for="VatExemptionTypeIds" value="@vatExemptionType.Id" checked="@(vatExemptionType.IsContainedIn(Model.VatExemptionTypeIds))"></smart-checkbox>
+                }
+                <smart-validation-message asp-for="VatExemptionTypeIds"></smart-validation-message>
+            </smart-formgroup>
+
+            <smart-formgroup label="@CatalogResources.TrainingTarget *">
+                @foreach (var targetAudience in TargetAudienceType.List)
+                {
+                    <smart-checkbox label="@Localizer[targetAudience.Name]" asp-for="TargetAudienceTypeIds" value="@targetAudience.Id" checked="@(targetAudience.IsContainedIn(Model.TargetAudienceTypeIds))"></smart-checkbox>
+                }
+                <smart-validation-message asp-for="TargetAudienceTypeIds"></smart-validation-message>
+            </smart-formgroup>
+
+            <smart-formgroup label="@CatalogResources.Training_IsItATrainingThat *">
+                @foreach (var attendanceType in AttendanceType.List)
+                {
+                    <smart-checkbox asp-for="AttendanceTypeIds" value="@attendanceType.Id" label="@Localizer["Training_" + attendanceType.Name]" checked="@(attendanceType.IsContainedIn(Model.AttendanceTypeIds))"></smart-checkbox>
+                }
+            </smart-formgroup>
+            <smart-validation-message asp-for="AttendanceTypeIds"></smart-validation-message>
+        </smart-panel>
+
+        <input type="hidden" id="isDraft" value="false" asp-for="IsDraft" />
+
+    </div>
+</form>
+<div class="c-tooltip" id="tooltip-title" role="tooltip">@CatalogResources.AddTrainingTooltip_Title
+    <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
+</div>
+
+<div class="c-tooltip" id="tooltip-presentation" role="tooltip">@CatalogResources.AddTrainingTooltip_Presentation
+    <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
+</div>
+
+<div class="c-tooltip" id="tooltip-objectif" role="tooltip">@CatalogResources.AddTrainingTooltip_Objectif
+    <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
+</div>
+
+<div class="c-tooltip" id="tooltip-modalities" role="tooltip">@CatalogResources.AddTrainingTooltip_Modalities
+    <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
+</div>

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/Index.cshtml
@@ -12,7 +12,6 @@
     ViewData.SetTitle(CatalogResources.EditTraining);
 }
 <div class="o-container">
-    <form method="post" id="form" class="u-spacer-xl">
 
         @section HeaderToolbar
         {
@@ -46,119 +45,9 @@
             </div>
         }
 
-        <div class="o-form-group-layout o-form-group-layout--standard">
-            <smart-panel header="@CatalogResources.FieldsThatWillAppearInThePublicCatalog">
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingTitleCreationLabel * <span data-tooltip="tooltip-title" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-input asp-for="UpdateTrainingViewModel.Title"></smart-input>
-                        <smart-validation-message asp-for="UpdateTrainingViewModel.Title"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-                
-                @if (Model.UserIdentity.IsSuperUser)
-                {
-                    <smart-checkbox label="@CatalogResources.IsTrainingGivenBySmart" asp-for="UpdateTrainingViewModel.IsGivenBySmart"></smart-checkbox>
-                    <smart-validation-message asp-for="UpdateTrainingViewModel.IsGivenBySmart"></smart-validation-message>
-                }
-
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingPresentation * <span data-tooltip="tooltip-presentation" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="UpdateTrainingViewModel.Methodology" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="UpdateTrainingViewModel.Methodology"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.TrainingGoal * <span data-tooltip="tooltip-objectif" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="UpdateTrainingViewModel.Goal" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="UpdateTrainingViewModel.Goal"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                <smart-formgroup>
-                    <label class="o-form-group__label">@CatalogResources.PracticalModalities * <span data-tooltip="tooltip-modalities" data-tooltip-placement="top" class="icon-help"><smart-icon icon="CircleHelp"></smart-icon></span></label>
-                    <smart-formgroup-controls>
-                        <smart-textarea asp-for="UpdateTrainingViewModel.PracticalModalities" rows="5"></smart-textarea>
-                        
-                        <p class="c-form-help-text">@CatalogResources.Min30CharMax1000Char</p>
-                        <smart-validation-message asp-for="UpdateTrainingViewModel.PracticalModalities"></smart-validation-message>
-                    </smart-formgroup-controls>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.Topics *">
-                    <smart-grid>
-                        @foreach (var topics in Topic.List.Chunk(2))
-                        {
-                            @foreach (var topic in topics)
-                            {
-                                <smart-grid-column width="4">
-                                    <smart-checkbox label="@_localizer[topic.Name]" asp-for="UpdateTrainingViewModel.TopicIds" value="@topic.Id" checked="@topic.IsContainedIn(Model.UpdateTrainingViewModel.TopicIds)"></smart-checkbox>
-                                </smart-grid-column>
-                            }
-                        }
-                    </smart-grid>
-                    <smart-validation-message asp-for="UpdateTrainingViewModel.TopicIds"></smart-validation-message>
-                </smart-formgroup>
-            </smart-panel>
-
-            <smart-spacer bottom="ExtraLarge" top="ExtraLarge"></smart-spacer>
-
-            <smart-panel header="@CatalogResources.TrainingVatJustification *">
-                <smart-formgroup label="@CatalogResources.TheTraining *">
-                    @foreach (var vatExemptionType in VatExemptionType.List)
-                    {
-                        <smart-checkbox label="@_localizer["Training_Is" + vatExemptionType.Name]" asp-for="UpdateTrainingViewModel.VatExemptionClaimIds" value="@vatExemptionType.Id" checked="@vatExemptionType.IsContainedIn(Model.UpdateTrainingViewModel.VatExemptionClaimIds)"></smart-checkbox>
-                    }
-                    <smart-validation-message asp-for="UpdateTrainingViewModel.VatExemptionClaimIds"></smart-validation-message>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.TrainingTarget *">
-                    @foreach (var targetAudience in TargetAudienceType.List)
-                    {
-                        <smart-checkbox label="@_localizer[targetAudience.Name]" asp-for="UpdateTrainingViewModel.TargetAudienceTypeIds" value="@targetAudience.Id" checked="@targetAudience.IsContainedIn(Model.UpdateTrainingViewModel.TargetAudienceTypeIds)"></smart-checkbox>
-                    }
-                    <smart-validation-message asp-for="UpdateTrainingViewModel.TargetAudienceTypeIds"></smart-validation-message>
-                </smart-formgroup>
-
-                <smart-formgroup label="@CatalogResources.Training_IsItATrainingThat *">
-                    @foreach (var attendanceType in AttendanceType.List)
-                    {
-                        <smart-checkbox asp-for="UpdateTrainingViewModel.AttendanceTypeIds" value="@attendanceType.Id" label="@_localizer["Training_" + attendanceType.Name]" checked="attendanceType.IsContainedIn(Model.UpdateTrainingViewModel.AttendanceTypeIds)"></smart-checkbox>
-                    }
-                    <smart-validation-message asp-for="UpdateTrainingViewModel.AttendanceTypeIds"></smart-validation-message>
-                </smart-formgroup>
-            </smart-panel>
-            <input type="hidden" id="isDraft" value="false" asp-for="UpdateTrainingViewModel.IsDraft"/>
-
-            <div class="u-spacer"></div>
-        </div>
-    </form>
+        @await Html.PartialAsync("Admin/Trainings/Shared/_TrainingCreationEditionForm", Model.UpdateTrainingViewModel)
 </div>
 
-<div>
-    <div class="c-tooltip" id="tooltip-title" role="tooltip">@CatalogResources.AddTrainingTooltip_Title
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-presentation" role="tooltip">@CatalogResources.AddTrainingTooltip_Presentation
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-objectif" role="tooltip">@CatalogResources.AddTrainingTooltip_Objectif
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-
-    <div class="c-tooltip" id="tooltip-modalities" role="tooltip">@CatalogResources.AddTrainingTooltip_Modalities
-        <div class="c-tooltip__arrow" data-popper-arrow="data-popper-arrow"></div>
-    </div>
-</div>
 <div class="u-spacer"></div>
 
 @section Scripts

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/UpdateTrainingViewModel.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Pages/Admin/Trainings/Update/UpdateTrainingViewModel.cs
@@ -3,35 +3,17 @@ using Smart.FA.Catalog.Application.UseCases.Queries;
 using Smart.FA.Catalog.Core.Domain.Dto;
 using Smart.FA.Catalog.Core.Domain.ValueObjects;
 using Smart.FA.Catalog.Shared.Domain.Enumerations.Training;
+using Smart.FA.Catalog.Web.Pages.Admin.Trainings.Create;
 
 namespace Smart.FA.Catalog.Web.Pages.Admin.Trainings.Update;
 
-public class UpdateTrainingViewModel
+public class UpdateTrainingViewModel : CreateTrainingViewModel
 {
-    public string? Title { get; init; }
-
-    public List<int>? AttendanceTypeIds { get; init; }
-
-    public List<int>? VatExemptionClaimIds { get; init; }
-
-    public List<int>? TargetAudienceTypeIds { get; init; }
-
-    public List<int>? TopicIds { get; init; }
-
-    public string? Goal { get; init; }
-
-    public string? Methodology { get; init; }
-
-    public bool IsDraft { get; set; }
-
-    public string? PracticalModalities { get; set; }
-
-    public bool IsGivenBySmart { get; set; }
 }
 
 public static class EditTrainingViewModelMapping
 {
-    public static UpdateTrainingRequest MapToUpdateRequest(this UpdateTrainingViewModel model, string language, int trainingId, int trainerId) =>
+    public static UpdateTrainingRequest MapToRequest(this UpdateTrainingViewModel model, string language, int trainingId, int trainerId) =>
         new()
         {
             DetailsDto =
@@ -44,7 +26,7 @@ public static class EditTrainingViewModelMapping
                     , model.PracticalModalities
                 ),
             TrainingId = trainingId,
-            VatExemptionTypes = VatExemptionType.FromValues(model.VatExemptionClaimIds ?? new()),
+            VatExemptionTypes = VatExemptionType.FromValues(model.VatExemptionTypeIds ?? new()),
             TargetAudienceTypes = TargetAudienceType.FromValues(model.TargetAudienceTypeIds ?? new()),
             AttendanceTypes = AttendanceType.FromValues(model.AttendanceTypeIds ?? new()),
             Topics = Topic.FromValues(model.TopicIds ?? new()),
@@ -54,7 +36,7 @@ public static class EditTrainingViewModelMapping
         };
 
 
-    public static UpdateTrainingViewModel MapGetToResponse(this GetTrainingFromIdResponse model, Language language)
+    public static UpdateTrainingViewModel MapToViewModel(this GetTrainingFromIdResponse model, Language language)
     {
         var details = model.Training!.Details.FirstOrDefault(localizedDetails => localizedDetails.Language == language);
         UpdateTrainingViewModel response = new()
@@ -64,7 +46,7 @@ public static class EditTrainingViewModelMapping
             Methodology = details?.Methodology,
             PracticalModalities = details?.PracticalModalities,
             TargetAudienceTypeIds = model.Training.Targets.Select(target => target.TargetAudienceType.Id).ToList(),
-            VatExemptionClaimIds = model.Training.VatExemptionClaims.Select(vatExemptionClaim => vatExemptionClaim.VatExemptionType.Id).ToList(),
+            VatExemptionTypeIds = model.Training.VatExemptionClaims.Select(vatExemptionClaim => vatExemptionClaim.VatExemptionType.Id).ToList(),
             AttendanceTypeIds = model.Training.Attendances.Select(attendance => attendance.AttendanceType.Id).ToList(),
             TopicIds = model.Training.Topics.Select(topic => topic.Topic.Id).ToList(),
             IsGivenBySmart = model.Training.IsGivenBySmart
@@ -73,7 +55,7 @@ public static class EditTrainingViewModelMapping
         return response;
     }
 
-    public static UpdateTrainingViewModel MapUpdateToResponse(this UpdateTrainingResponse model, Language language)
+    public static UpdateTrainingViewModel MapToViewModel(this UpdateTrainingResponse model, Language language)
     {
         var detail = model.Training.Details.FirstOrDefault(detail => detail.Language == language);
         UpdateTrainingViewModel response = new()
@@ -83,7 +65,7 @@ public static class EditTrainingViewModelMapping
             Methodology = detail?.Methodology,
             PracticalModalities = detail?.PracticalModalities,
             TargetAudienceTypeIds = model.Training.Targets.Select(target => target.TargetAudienceType.Id).ToList(),
-            VatExemptionClaimIds = model.Training.VatExemptionClaims.Select(vatExemptionClaim => vatExemptionClaim.VatExemptionType.Id).ToList(),
+            VatExemptionTypeIds = model.Training.VatExemptionClaims.Select(vatExemptionClaim => vatExemptionClaim.VatExemptionType.Id).ToList(),
             AttendanceTypeIds = model.Training.Attendances.Select(attendance => attendance.AttendanceType.Id).ToList(),
             IsGivenBySmart = model.Training.IsGivenBySmart,
             IsDraft = model.Training.StatusType == TrainingStatusType.Draft

--- a/src/UserAdmin/src/Smart.FA.Catalog.Web/Validators/UpdateTrainingRequestValidator.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Web/Validators/UpdateTrainingRequestValidator.cs
@@ -67,7 +67,7 @@ public class UpdateTrainingViewModelValidator : AbstractValidator<UpdateTraining
             .NotEmpty()
             .WithMessage(CatalogResources.YouMustSelectedAtLeastOneTopic);
 
-        RuleFor(viewModel => viewModel.VatExemptionClaimIds)
+        RuleFor(viewModel => viewModel.VatExemptionTypeIds)
             .NotEmpty()
             .WithMessage(CatalogResources.PleaseSelectOneOption);
 


### PR DESCRIPTION
Simply move the HTML of the form to create or edit a training into a partial view.
This will help maintaining those two pages.

If somebody got a better naming for
[_TrainingCreationEditionForm.cshtml](https://github.com/smartcoop/smart-cfa/pull/239/files#diff-b43f5e5d2115aab83f76fa130af49942db3ac6369055dd9d1618a200557c3554) say so :).

This PR is required for https://smartjira.atlassian.net/browse/CFA-432