### PR TITLE
Remove old system for paging (with sql server update)

### DIFF
--- a/src/Showcase/src/Smart.FA.Catalog.Showcase.Web/Smart.FA.Catalog.Showcase.Web.csproj
+++ b/src/Showcase/src/Smart.FA.Catalog.Showcase.Web/Smart.FA.Catalog.Showcase.Web.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFrameworkCore.UseRowNumberForPaging" Version="0.3.0" />
     <PackageReference Include="FluentEmail.MailKit" Version="3.0.2" />
     <PackageReference Include="Hangfire" Version="1.7.28" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />

--- a/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using Amazon;
 using Amazon.S3;
-using EntityFrameworkCore.UseRowNumberForPaging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,7 +91,7 @@ public static class ServiceCollectionExtensions
             });
 
             options
-                .UseSqlServer(connectionString, options => options.UseRowNumberForPaging())
+                .UseSqlServer(connectionString)
                 .UseLazyLoadingProxies();
             if (efCoreOptions.Value.UseConsoleLogger)
             {

--- a/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Smart.FA.Catalog.Infrastructure.csproj
+++ b/src/UserAdmin/src/Smart.FA.Catalog.Infrastructure/Smart.FA.Catalog.Infrastructure.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.8.7" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Dapper.Transaction" Version="2.0.35.2" />
-    <PackageReference Include="EntityFrameworkCore.UseRowNumberForPaging" Version="0.3.0" />
     <PackageReference Include="Hashids.net" Version="1.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="6.0.0-preview.4.21253.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />


### PR DESCRIPTION
This PR removes the use of a nuget package allowing ef core to translate skip and take with ef core in old SQL language (ROW NUMBER) supported on SQL 2005. With the migration in production to a newer version of SQL, it is not needed anymore.